### PR TITLE
Generate SBOMs for source code and Docker image and upload it to the release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,20 +30,6 @@ jobs:
         run: make build-release
       - name: Build and release Linux packages
         run: make build-linux-packages
-      - name: Create release and add artifacts
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            dist/*.tar.gz
-            dist/checksums.txt
-            dist/*.deb
-            dist/*.rpm
-            dist/*.zip
-          draft: false
-          prerelease: false
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
       - name: Sign in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -66,3 +52,30 @@ jobs:
             ghcr.io/gatewayd-io/gatewayd:${{ github.ref_name }}
             ghcr.io/gatewayd-io/gatewayd:latest
           platforms: linux/amd64
+      - name: Scan Docker image with Syft and generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          artifact-name: gatewayd-image-${{ github.ref_name }}.cyclonedx.json
+          format: cyclonedx-json
+          dependency-snapshot: true
+          image: gatewaydio/gatewayd:${{ github.ref_name }}
+      - name: Scan source code and generate SBOM
+        run: |
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+          cyclonedx-gomod mod -json -licenses -output gatewayd-source-${{ github.ref_name }}.cyclonedx.json
+      - name: Create release and add artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/checksums.txt
+            dist/*.deb
+            dist/*.rpm
+            dist/*.zip
+            gatewayd-image-${{ github.ref_name }}.cyclonedx.json
+            gatewayd-source-${{ github.ref_name }}.cyclonedx.json
+          draft: false
+          prerelease: false
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
# Ticket(s)
- https://github.com/gatewayd-io/gatewayd/issues/138

## Description
This PR delays creating the release with the new tag (version) until after the image is created. The reason is that it needs to generate the SBOMs for the image before uploading them. Along with that, the SBOM for the source code and their licenses are also generated and uploaded to the release assets.

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
