### PR TITLE
Fix a regression in `plugin install` command

### DIFF
--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -97,8 +97,8 @@ var pluginInstallCmd = &cobra.Command{
 				log.Panic(
 					"Invalid URL. Use the following format: github.com/account/repository@version")
 			}
-			account := accountRepo[0]
-			pluginName := accountRepo[1]
+			account = accountRepo[0]
+			pluginName = accountRepo[1]
 			if account == "" || pluginName == "" {
 				log.Panic(
 					"Invalid URL. Use the following format: github.com/account/repository@version")


### PR DESCRIPTION
# Ticket(s)
N/A

## Description
I found that the `gateway plugin install` command to properly install plugins, and fails in the middle. This is a regression I introduced in #310, which I fixed in this PR.

## Related PRs
- #310

## Development Checklist

- [ ] I have added a descriptive title to this PR.
- [ ] I have squashed related commits together.
- [ ] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
