### PR TITLE
Add receive timeout

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -407,6 +407,7 @@ var runCmd = &cobra.Command{
 			// Fill the missing and zero values with the default ones.
 			clients[name].TCPKeepAlivePeriod = clients[name].GetTCPKeepAlivePeriod()
 			clients[name].ReceiveDeadline = clients[name].GetReceiveDeadline()
+			clients[name].ReceiveTimeout = clients[name].GetReceiveTimeout()
 			clients[name].SendDeadline = clients[name].GetSendDeadline()
 			clients[name].ReceiveChunkSize = clients[name].GetReceiveChunkSize()
 

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,7 @@ func (c *Config) LoadDefaults(ctx context.Context) {
 		TCPKeepAlivePeriod: DefaultTCPKeepAlivePeriod,
 		ReceiveChunkSize:   DefaultChunkSize,
 		ReceiveDeadline:    DefaultReceiveDeadline,
+		ReceiveTimeout:     DefaultReceiveTimeout,
 		SendDeadline:       DefaultSendDeadline,
 	}
 

--- a/config/constants.go
+++ b/config/constants.go
@@ -101,6 +101,7 @@ const (
 	DefaultSendDeadline       = 0
 	DefaultTCPKeepAlivePeriod = 30 * time.Second
 	DefaultTCPKeepAlive       = false
+	DefaultReceiveTimeout     = 0
 
 	// Pool constants.
 	EmptyPoolCapacity        = 0

--- a/config/getters.go
+++ b/config/getters.go
@@ -126,6 +126,14 @@ func (c Client) GetReceiveDeadline() time.Duration {
 	return c.ReceiveDeadline
 }
 
+// GetReceiveTimeout returns the receive timeout from config file or default value.
+func (c Client) GetReceiveTimeout() time.Duration {
+	if c.ReceiveTimeout <= 0 {
+		return DefaultReceiveTimeout
+	}
+	return c.ReceiveTimeout
+}
+
 // GetSendDeadline returns the send deadline from config file or default value.
 func (c Client) GetSendDeadline() time.Duration {
 	if c.SendDeadline <= 0 {

--- a/config/types.go
+++ b/config/types.go
@@ -44,6 +44,7 @@ type Client struct {
 	TCPKeepAlivePeriod time.Duration `json:"tcpKeepAlivePeriod" jsonschema:"oneof_type=string;integer"`
 	ReceiveChunkSize   int           `json:"receiveChunkSize"`
 	ReceiveDeadline    time.Duration `json:"receiveDeadline" jsonschema:"oneof_type=string;integer"`
+	ReceiveTimeout     time.Duration `json:"receiveTimeout" jsonschema:"oneof_type=string;integer"`
 	SendDeadline       time.Duration `json:"sendDeadline" jsonschema:"oneof_type=string;integer"`
 }
 

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -33,6 +33,7 @@ clients:
     tcpKeepAlivePeriod: 30s # duration
     receiveChunkSize: 8192
     receiveDeadline: 0s # duration, 0ms/0s means no deadline
+    receiveTimeout: 0s # duration, 0ms/0s means no timeout
     sendDeadline: 0s # duration, 0ms/0s means no deadline
 
 pools:

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -30,6 +30,7 @@ func CreateNewClient(t *testing.T) *Client {
 			Address:            "localhost:5432",
 			ReceiveChunkSize:   config.DefaultChunkSize,
 			ReceiveDeadline:    config.DefaultReceiveDeadline,
+			ReceiveTimeout:     config.DefaultReceiveTimeout,
 			SendDeadline:       config.DefaultSendDeadline,
 			TCPKeepAlive:       false,
 			TCPKeepAlivePeriod: config.DefaultTCPKeepAlivePeriod,


### PR DESCRIPTION
# Ticket(s)
- #327 

## Description
This PR adds a small feature for having a context that times out when blocking on `client.Receive`. This helps prevents `client.Receive` from blocking the entire message flow, thus hanging the servers and clients. Note that by default the value is `0`, which means it'll work just like before, until one sets a time limit. It is recommended to set it to a relative value that your queries might take to be answered by the database server. Also, this is different from the `client.ReceiveDeadline`, in that it doesn't kill the connection, but instead stops waiting to receive new values from the client connection.

## Related PRs

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
