### PR TITLE
Lint on run

### DIFF
--- a/cmd/config_lint.go
+++ b/cmd/config_lint.go
@@ -31,7 +31,11 @@ var configLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		lintConfig(cmd, Global, globalConfigFile)
+		if err := lintConfig(Global, globalConfigFile); err != nil {
+			log.Fatal(err)
+		}
+
+		cmd.Println("global config is valid")
 	},
 }
 

--- a/cmd/plugin_lint.go
+++ b/cmd/plugin_lint.go
@@ -31,7 +31,11 @@ var pluginLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		lintConfig(cmd, Plugins, pluginConfigFile)
+		if err := lintConfig(Plugins, pluginConfigFile); err != nil {
+			log.Fatal(err)
+		}
+
+		cmd.Println("plugins config is valid")
 	},
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -32,6 +32,7 @@ const (
 	ErrCodeDuplicateMetricsCollector
 	ErrCodeInvalidMetricType
 	ErrCodeValidationFailed
+	ErrCodeLintingFailed
 )
 
 var (
@@ -104,6 +105,8 @@ var (
 
 	ErrValidationFailed = NewGatewayDError(
 		ErrCodeValidationFailed, "validation failed", nil)
+	ErrLintingFailed = NewGatewayDError(
+		ErrCodeLintingFailed, "linting failed", nil)
 )
 
 const (

--- a/network/proxy_test.go
+++ b/network/proxy_test.go
@@ -19,7 +19,7 @@ func TestNewProxy(t *testing.T) {
 		Output:            []config.LogOutput{config.Console},
 		TimeFormat:        zerolog.TimeFormatUnix,
 		ConsoleTimeFormat: time.RFC3339,
-		Level:             zerolog.DebugLevel,
+		Level:             zerolog.WarnLevel,
 		NoColor:           true,
 	})
 
@@ -82,7 +82,7 @@ func TestNewProxyElastic(t *testing.T) {
 		Output:            []config.LogOutput{config.Console},
 		TimeFormat:        zerolog.TimeFormatUnix,
 		ConsoleTimeFormat: time.RFC3339,
-		Level:             zerolog.DebugLevel,
+		Level:             zerolog.WarnLevel,
 		NoColor:           true,
 	})
 

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -31,7 +31,7 @@ func TestRunServer(t *testing.T) {
 		},
 		TimeFormat:        zerolog.TimeFormatUnix,
 		ConsoleTimeFormat: time.RFC3339,
-		Level:             zerolog.DebugLevel,
+		Level:             zerolog.WarnLevel,
 		NoColor:           true,
 		FileName:          "server_test.log",
 	})


### PR DESCRIPTION
# Ticket(s)
- #255 

## Description
This PR adds a feature to lint global and plugins configuration while running GatewayD.

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
