### PR TITLE
Shutdown metrics server gracefully

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -402,8 +402,9 @@ var runCmd = &cobra.Command{
 
 			// Create a new metrics server.
 			metricsServer = &http.Server{
-				Addr:    metricsConfig.Address,
-				Handler: handler,
+				Addr:              metricsConfig.Address,
+				Handler:           handler,
+				ReadHeaderTimeout: metricsConfig.GetReadHeaderTimeout(),
 			}
 
 			// Start the metrics server.
@@ -414,7 +415,6 @@ var runCmd = &cobra.Command{
 		}(conf.Global.Metrics[config.Default], logger)
 
 		// This is a notification hook, so we don't care about the result.
-		// TODO: Use a context with a timeout
 		if data, ok := conf.GlobalKoanf.Get("loggers").(map[string]interface{}); ok {
 			_, err = pluginRegistry.Run(
 				pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_LOGGER)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -34,6 +34,7 @@ func Test_runCmd(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			nil,
 			loggers[config.Default],
 			servers,
 			stopChan,
@@ -112,6 +113,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		StopGracefully(
 			runCmd.Context(),
 			runCmd.Context(),
+			nil,
 			nil,
 			nil,
 			nil,

--- a/config/config.go
+++ b/config/config.go
@@ -101,9 +101,10 @@ func (c *Config) LoadDefaults(ctx context.Context) {
 	}
 
 	defaultMetric := Metrics{
-		Enabled: true,
-		Address: DefaultMetricsAddress,
-		Path:    DefaultMetricsPath,
+		Enabled:           true,
+		Address:           DefaultMetricsAddress,
+		Path:              DefaultMetricsPath,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
 	}
 
 	defaultClient := Client{

--- a/config/constants.go
+++ b/config/constants.go
@@ -123,8 +123,9 @@ const (
 	ChecksumBufferSize = 65536
 
 	// Metrics constants.
-	DefaultMetricsAddress = "localhost:9090"
-	DefaultMetricsPath    = "/metrics"
+	DefaultMetricsAddress    = "localhost:9090"
+	DefaultMetricsPath       = "/metrics"
+	DefaultReadHeaderTimeout = 10 * time.Second
 
 	// Sentry constants.
 	DefaultTraceSampleRate  = 0.2

--- a/config/getters.go
+++ b/config/getters.go
@@ -269,3 +269,10 @@ func GetDefaultConfigFilePath(filename string) string {
 	// The fallback is the current directory.
 	return filepath.Join("./", filename)
 }
+
+func (m Metrics) GetReadHeaderTimeout() time.Duration {
+	if m.ReadHeaderTimeout <= 0 {
+		return DefaultReadHeaderTimeout
+	}
+	return m.ReadHeaderTimeout
+}

--- a/config/getters_test.go
+++ b/config/getters_test.go
@@ -128,3 +128,9 @@ func TestGetPlugins(t *testing.T) {
 func TestGetDefaultConfigFilePath(t *testing.T) {
 	assert.Equal(t, GlobalConfigFilename, GetDefaultConfigFilePath(GlobalConfigFilename))
 }
+
+// TestGetReadTimeout tests the GetReadTimeout function.
+func TestGetReadHeaderTimeout(t *testing.T) {
+	metrics := Metrics{}
+	assert.Equal(t, DefaultReadHeaderTimeout, metrics.GetReadHeaderTimeout())
+}

--- a/config/types.go
+++ b/config/types.go
@@ -68,9 +68,10 @@ type Logger struct {
 }
 
 type Metrics struct {
-	Enabled bool   `json:"enabled"`
-	Address string `json:"address"`
-	Path    string `json:"path"`
+	Enabled           bool          `json:"enabled"`
+	Address           string        `json:"address"`
+	Path              string        `json:"path"`
+	ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" jsonschema:"oneof_type=string;integer"`
 }
 
 type Pool struct {

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -24,6 +24,7 @@ metrics:
     enabled: True
     address: localhost:9090
     path: /metrics
+    readHeaderTimeout: 10s # duration, prevents Slowloris attacks
 
 clients:
   default:

--- a/metrics/utils.go
+++ b/metrics/utils.go
@@ -1,0 +1,19 @@
+package metrics
+
+import "net/http"
+
+// HeaderBypassResponseWriter implements the http.ResponseWriter interface
+// and allows us to bypass the response header when writing to the response.
+// This is useful for merging metrics from multiple sources.
+type HeaderBypassResponseWriter struct {
+	http.ResponseWriter
+}
+
+// WriteHeader intentionally does nothing, but is required to
+// implement the http.ResponseWriter.
+func (w *HeaderBypassResponseWriter) WriteHeader(code int) {}
+
+// Write writes the data to the response.
+func (w *HeaderBypassResponseWriter) Write(data []byte) (int, error) {
+	return w.ResponseWriter.Write(data)
+}

--- a/metrics/utils.go
+++ b/metrics/utils.go
@@ -11,9 +11,9 @@ type HeaderBypassResponseWriter struct {
 
 // WriteHeader intentionally does nothing, but is required to
 // implement the http.ResponseWriter.
-func (w *HeaderBypassResponseWriter) WriteHeader(code int) {}
+func (w *HeaderBypassResponseWriter) WriteHeader(int) {}
 
 // Write writes the data to the response.
 func (w *HeaderBypassResponseWriter) Write(data []byte) (int, error) {
-	return w.ResponseWriter.Write(data)
+	return w.ResponseWriter.Write(data) //nolint:wrapcheck
 }


### PR DESCRIPTION
# Ticket(s)
- #333 

## Description
This PR fixes a bug in writing HTTP headers (by calling `WriteHeader`) twice and adds a graceful shutdown to the HTTP server (for metrics).

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [x] I have ~added~fixed tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
