### PR TITLE
TLS support in metrics server

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -123,9 +123,10 @@ const (
 	ChecksumBufferSize = 65536
 
 	// Metrics constants.
-	DefaultMetricsAddress    = "localhost:9090"
-	DefaultMetricsPath       = "/metrics"
-	DefaultReadHeaderTimeout = 10 * time.Second
+	DefaultMetricsAddress       = "localhost:9090"
+	DefaultMetricsPath          = "/metrics"
+	DefaultReadHeaderTimeout    = 10 * time.Second
+	DefaultMetricsServerTimeout = 10 * time.Second
 
 	// Sentry constants.
 	DefaultTraceSampleRate  = 0.2

--- a/config/getters.go
+++ b/config/getters.go
@@ -276,3 +276,10 @@ func (m Metrics) GetReadHeaderTimeout() time.Duration {
 	}
 	return m.ReadHeaderTimeout
 }
+
+func (m Metrics) GetTimeout() time.Duration {
+	if m.Timeout <= 0 {
+		return DefaultMetricsServerTimeout
+	}
+	return m.Timeout
+}

--- a/config/types.go
+++ b/config/types.go
@@ -72,6 +72,9 @@ type Metrics struct {
 	Address           string        `json:"address"`
 	Path              string        `json:"path"`
 	ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" jsonschema:"oneof_type=string;integer"`
+	Timeout           time.Duration `json:"timeout" jsonschema:"oneof_type=string;integer"`
+	CertFile          string        `json:"certFile"`
+	KeyFile           string        `json:"keyFile"`
 }
 
 type Pool struct {

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -25,6 +25,9 @@ metrics:
     address: localhost:9090
     path: /metrics
     readHeaderTimeout: 10s # duration, prevents Slowloris attacks
+    timeout: 10s # duration
+    certFile: "" # Certificate file in PEM format
+    keyFile: "" # Private key file in PEM format
 
 clients:
   default:


### PR DESCRIPTION
# Ticket(s)
- #334 

## Description
This PR adds two features:
1. TLS support in metrics server.
2. A link on root of the metrics server to the metrics endpoint

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
