### PR TITLE
Update plugin in the list and backup plugins config when using `plugin install`

### DIFF
--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
@@ -24,7 +22,8 @@ var configInitCmd = &cobra.Command{
 				AttachStacktrace: config.DefaultAttachStacktrace,
 			})
 			if err != nil {
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/config_lint.go
+++ b/cmd/config_lint.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package cmd
 
 import (

--- a/cmd/config_lint.go
+++ b/cmd/config_lint.go
@@ -22,7 +22,8 @@ var configLintCmd = &cobra.Command{
 				AttachStacktrace: config.DefaultAttachStacktrace,
 			})
 			if err != nil {
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/plugin_init.go
+++ b/cmd/plugin_init.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
@@ -22,7 +20,8 @@ var pluginInitCmd = &cobra.Command{
 				AttachStacktrace: config.DefaultAttachStacktrace,
 			})
 			if err != nil {
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -142,8 +142,14 @@ var pluginInstallCmd = &cobra.Command{
 			release, _, err = client.Repositories.GetReleaseByTag(
 				context.Background(), account, pluginName, pluginVersion)
 		}
-		if err != nil || release == nil {
-			cmd.Println("The plugin could not be found")
+
+		if err != nil {
+			cmd.Println("The plugin could not be found: ", err.Error())
+			return
+		}
+
+		if release == nil {
+			cmd.Println("The plugin could not be found in the release assets")
 			return
 		}
 

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -77,6 +77,10 @@ var pluginInstallCmd = &cobra.Command{
 		var client *github.Client
 		var account string
 
+		// Strip scheme from the plugin URL.
+		args[0] = strings.TrimPrefix(args[0], "http://")
+		args[0] = strings.TrimPrefix(args[0], "https://")
+
 		if !strings.HasPrefix(args[0], GitHubURLPrefix) {
 			// Pull the plugin from a local archive.
 			pluginFilename = filepath.Clean(args[0])

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -36,6 +36,7 @@ var (
 	cleanup         bool
 	update          bool
 	backupConfig    bool
+	noPrompt        bool
 )
 
 // pluginInstallCmd represents the plugin install command.
@@ -233,7 +234,7 @@ var pluginInstallCmd = &cobra.Command{
 		} else {
 			// If the config file exists, we should prompt the user to backup
 			// the plugins configuration file.
-			if !backupConfig {
+			if !backupConfig && !noPrompt {
 				cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
 				var backupOption string
 				_, err := fmt.Scanln(&backupOption)
@@ -273,12 +274,14 @@ var pluginInstallCmd = &cobra.Command{
 				if pluginInstance["name"] == pluginName {
 					// Show a list of options to the user.
 					cmd.Println("Plugin is already installed.")
-					cmd.Print("Do you want to update the plugin? [y/N] ")
+					if !noPrompt {
+						cmd.Print("Do you want to update the plugin? [y/N] ")
 
-					var updateOption string
-					_, err := fmt.Scanln(&updateOption)
-					if err == nil && (updateOption == "y" || updateOption == "Y") {
-						break
+						var updateOption string
+						_, err := fmt.Scanln(&updateOption)
+						if err == nil && (updateOption == "y" || updateOption == "Y") {
+							break
+						}
 					}
 
 					cmd.Println("Aborting...")
@@ -443,6 +446,8 @@ func init() {
 	pluginInstallCmd.Flags().BoolVar(
 		&cleanup, "cleanup", true,
 		"Delete downloaded and extracted files after installing the plugin (except the plugin binary)")
+	pluginInstallCmd.Flags().BoolVar(
+		&noPrompt, "no-prompt", true, "Do not prompt for user input")
 	pluginInstallCmd.Flags().BoolVar(
 		&update, "update", false, "Update the plugin if it already exists")
 	pluginInstallCmd.Flags().BoolVar(

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -22,7 +22,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 	output, err = executeCommandC(
 		rootCmd, "plugin", "install",
 		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
-		"-p", pluginTestConfigFile, "--update")
+		"-p", pluginTestConfigFile, "--update", "--backup")
 	assert.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll
@@ -38,6 +38,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 
 	// Clean up.
 	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
+	assert.FileExists(t, fmt.Sprintf("%s.bak", pluginTestConfigFile))
 	assert.NoFileExists(t, "gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz")
 	assert.NoFileExists(t, "checksums.txt")
 	assert.NoFileExists(t, "plugins/LICENSE")
@@ -47,4 +48,5 @@ func Test_pluginInstallCmd(t *testing.T) {
 
 	assert.NoError(t, os.RemoveAll("plugins/"))
 	assert.NoError(t, os.Remove(pluginTestConfigFile))
+	assert.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfigFile)))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -21,7 +21,8 @@ func Test_pluginInstallCmd(t *testing.T) {
 	// Test plugin install command.
 	output, err = executeCommandC(
 		rootCmd, "plugin", "install",
-		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4", "-p", pluginTestConfigFile)
+		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
+		"-p", pluginTestConfigFile, "--update")
 	assert.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll

--- a/cmd/plugin_lint.go
+++ b/cmd/plugin_lint.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package cmd
 
 import (

--- a/cmd/plugin_lint.go
+++ b/cmd/plugin_lint.go
@@ -22,7 +22,8 @@ var pluginLintCmd = &cobra.Command{
 				AttachStacktrace: config.DefaultAttachStacktrace,
 			})
 			if err != nil {
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/plugin_list.go
+++ b/cmd/plugin_list.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
@@ -24,7 +22,8 @@ var pluginListCmd = &cobra.Command{
 				AttachStacktrace: config.DefaultAttachStacktrace,
 			})
 			if err != nil {
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -176,7 +176,8 @@ var runCmd = &cobra.Command{
 			})
 			if err != nil {
 				span.RecordError(err)
-				log.Panic("Sentry initialization failed: ", err)
+				cmd.Println("Sentry initialization failed: ", err)
+				return
 			}
 
 			// Flush buffered events before the program terminates.

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -147,7 +147,8 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",
-		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4", "-p", pluginTestConfigFile)
+		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
+		"-p", pluginTestConfigFile, "--update")
 	assert.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -447,3 +447,13 @@ func downloadFile(
 
 	return filePath
 }
+
+// deleteFiles deletes the files in the toBeDeleted list.
+func deleteFiles(toBeDeleted []string) {
+	for _, filename := range toBeDeleted {
+		if err := os.Remove(filename); err != nil {
+			log.Println("There was an error deleting the file: ", err)
+			return
+		}
+	}
+}


### PR DESCRIPTION
# Ticket(s)
- #312 

## Description
In this PR, I've introduced some new features:

1. I've added an option to enable interactive prompt when updating the plugin or backing up the plugins config file before the update. To activate the interactive prompt, you can use the `--no-prompt=false` flag.
2. When using the `plugin install` command, users can now choose whether they want to create a backup of the current plugins config file (if it exists) before proceeding with the installation. This can be achieved by using the `--backup=true` flag.
3. The updated `plugin install` command will replace the plugin configuration of the newly installed plugin with any existing configuration for a plugin in the plugins list that shares the same name. You can enable this behavior using the `--update=true` flag.

> **Warning**
> **Important Change in `plugin install` Command**
> Starting with this update, there is a breaking change in the `plugin install` command. By default, the interactive prompt is now disabled (`--no-prompt=true`) when installing a new plugin. If an existing plugin with the same name is detected during installation, the process will be aborted, and any downloaded files will be automatically deleted.
>
> To override this default behavior and have more control:
>
>1. Enable the interactive prompt to be notified of the changes and have the option to approve or deny them.
> 2. Pass the appropriate flags to enable the update and backup features.
>
> These changes are aimed at enhancing your control over the installation process and minimizing any unexpected actions when dealing with plugins. Please adjust your installation process accordingly to accommodate these modifications.

## Related PRs
- https://github.com/gatewayd-io/docs/pull/31

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [x] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
