### PR TITLE
Print and return instead of `log.Panic`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,7 @@ linters:
     - structcheck
     - varcheck
     - golint
+    - testifylint
 linters-settings:
   depguard:
     rules:

--- a/cmd/config_init_test.go
+++ b/cmd/config_init_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_configInitCmd(t *testing.T) {
 	// Test configInitCmd.
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
-	assert.NoError(t, err, "configInitCmd should not return an error")
+	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
 		output,
@@ -21,7 +22,7 @@ func Test_configInitCmd(t *testing.T) {
 
 	// Test configInitCmd with the --force flag to overwrite the config file.
 	output, err = executeCommandC(rootCmd, "config", "init", "--force")
-	assert.NoError(t, err, "configInitCmd should not return an error")
+	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was overwritten successfully.", globalTestConfigFile),
 		output,
@@ -29,5 +30,5 @@ func Test_configInitCmd(t *testing.T) {
 
 	// Clean up.
 	err = os.Remove(globalTestConfigFile)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }

--- a/cmd/config_lint_test.go
+++ b/cmd/config_lint_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_configLintCmd(t *testing.T) {
 	// Test configInitCmd.
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
-	assert.NoError(t, err, "configInitCmd should not return an error")
+	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
 		output,
@@ -21,7 +22,7 @@ func Test_configLintCmd(t *testing.T) {
 
 	// Test configLintCmd.
 	output, err = executeCommandC(rootCmd, "config", "lint", "-c", globalTestConfigFile)
-	assert.NoError(t, err, "configLintCmd should not return an error")
+	require.NoError(t, err, "configLintCmd should not return an error")
 	assert.Equal(t,
 		"global config is valid\n",
 		output,
@@ -29,5 +30,5 @@ func Test_configLintCmd(t *testing.T) {
 
 	// Clean up.
 	err = os.Remove(globalTestConfigFile)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_configCmd(t *testing.T) {
 	// Test configCmd with no arguments.
 	output, err := executeCommandC(rootCmd, "config")
-	assert.NoError(t, err, "configCmd should not return an error")
+	require.NoError(t, err, "configCmd should not return an error")
 	assert.Equal(t,
 		`Manage GatewayD global configuration
 

--- a/cmd/plugin_init_test.go
+++ b/cmd/plugin_init_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_pluginInitCmd(t *testing.T) {
 	// Test plugin init command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init command should not have returned an error")
+	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
 		output,
@@ -20,5 +21,5 @@ func Test_pluginInitCmd(t *testing.T) {
 
 	// Clean up.
 	err = os.Remove(pluginTestConfigFile)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_pluginInstallCmd(t *testing.T) {
 	// Create a test plugin config file.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init should not return an error")
+	require.NoError(t, err, "plugin init should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
 		output,
@@ -23,7 +24,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 		rootCmd, "plugin", "install",
 		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
 		"-p", pluginTestConfigFile, "--update", "--backup")
-	assert.NoError(t, err, "plugin install should not return an error")
+	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll
 	assert.Contains(t, output, "Download completed successfully")
@@ -33,7 +34,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin list should not return an error")
+	require.NoError(t, err, "plugin list should not return an error")
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
 	// Clean up.
@@ -46,7 +47,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 	assert.NoFileExists(t, "plugins/checksum.txt")
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
-	assert.NoError(t, os.RemoveAll("plugins/"))
-	assert.NoError(t, os.Remove(pluginTestConfigFile))
-	assert.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfigFile)))
+	require.NoError(t, os.RemoveAll("plugins/"))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
+	require.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfigFile)))
 }

--- a/cmd/plugin_lint_test.go
+++ b/cmd/plugin_lint_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_pluginLintCmd(t *testing.T) {
 	// Test plugin lint command.
 	output, err := executeCommandC(rootCmd, "plugin", "lint", "-p", "../gatewayd_plugins.yaml")
-	assert.NoError(t, err, "plugin lint command should not have returned an error")
+	require.NoError(t, err, "plugin lint command should not have returned an error")
 	assert.Equal(t,
 		"plugins config is valid\n",
 		output,

--- a/cmd/plugin_list_test.go
+++ b/cmd/plugin_list_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_pluginListCmd(t *testing.T) {
 	// Test plugin list command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init command should not have returned an error")
+	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
 		output,
@@ -19,7 +20,7 @@ func Test_pluginListCmd(t *testing.T) {
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin list command should not have returned an error")
+	require.NoError(t, err, "plugin list command should not have returned an error")
 	assert.Equal(t,
 		"No plugins found\n",
 		output,
@@ -27,7 +28,7 @@ func Test_pluginListCmd(t *testing.T) {
 
 	// Clean up.
 	err = os.Remove(pluginTestConfigFile)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 }
 
 func Test_pluginListCmdWithPlugins(t *testing.T) {
@@ -35,7 +36,7 @@ func Test_pluginListCmdWithPlugins(t *testing.T) {
 	// Read the plugin config file from the root directory.
 	pluginTestConfigFile := "../gatewayd_plugins.yaml"
 	output, err := executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin list command should not have returned an error")
+	require.NoError(t, err, "plugin list command should not have returned an error")
 	assert.Equal(t, `Total plugins: 1
 Plugins:
   Name: gatewayd-plugin-cache

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_pluginCmd(t *testing.T) {
 	// Test pluginCmd with no arguments.
 	output, err := executeCommandC(rootCmd, "plugin")
-	assert.NoError(t, err, "pluginCmd should not return an error")
+	require.NoError(t, err, "pluginCmd should not return an error")
 	assert.Equal(t, `Manage plugins and their configuration
 
 Usage:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_rootCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd)
-	assert.NoError(t, err, "rootCmd should not return an error")
+	require.NoError(t, err, "rootCmd should not return an error")
 	//nolint:lll
 	assert.Equal(t,
 		`GatewayD is a cloud-native database gateway and framework for building data-driven applications. It sits between your database servers and clients and proxies all their communication.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -155,7 +155,8 @@ var runCmd = &cobra.Command{
 			shutdown := tracing.OTLPTracer(true, collectorURL, config.TracerName)
 			defer func() {
 				if err := shutdown(context.Background()); err != nil {
-					log.Panic(err)
+					cmd.Println(err)
+					os.Exit(gerr.FailedToStartTracer)
 				}
 			}()
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -571,7 +571,7 @@ var runCmd = &cobra.Command{
 			// Verify that the pool is properly populated.
 			logger.Info().Fields(map[string]interface{}{
 				"name":  name,
-				"count": fmt.Sprint(pools[name].Size()),
+				"count": strconv.Itoa(pools[name].Size()),
 			}).Msg("There are clients available in the pool")
 
 			if pools[name].Size() != cfg.GetSize() {
@@ -747,7 +747,7 @@ var runCmd = &cobra.Command{
 				}
 				pluginRegistry.ForEach(
 					func(identifier sdkPlugin.Identifier, plugin *plugin.Plugin) {
-						report.Plugins = append(report.Plugins, &usage.Plugin{
+						report.Plugins = append(report.GetPlugins(), &usage.Plugin{
 							Name:     identifier.Name,
 							Version:  identifier.Version,
 							Checksum: identifier.Checksum,

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -9,18 +9,19 @@ import (
 
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zenizh/go-capturer"
 )
 
 func Test_runCmd(t *testing.T) {
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init command should not have returned an error")
+	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	// Create a test config file.
 	_, err = executeCommandC(rootCmd, "config", "init", "--force", "-c", globalTestConfigFile)
-	assert.NoError(t, err, "configInitCmd should not return an error")
+	require.NoError(t, err, "configInitCmd should not return an error")
 	// Check that the config file was created.
 	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
@@ -48,7 +49,7 @@ func Test_runCmd(t *testing.T) {
 		// Test run command.
 		output := capturer.CaptureOutput(func() {
 			_, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
-			assert.NoError(t, err, "run command should not have returned an error")
+			require.NoError(t, err, "run command should not have returned an error")
 		})
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
@@ -68,8 +69,8 @@ func Test_runCmd(t *testing.T) {
 	waitGroup.Wait()
 
 	// Clean up.
-	assert.NoError(t, os.Remove(pluginTestConfigFile))
-	assert.NoError(t, os.Remove(globalTestConfigFile))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
+	require.NoError(t, os.Remove(globalTestConfigFile))
 }
 
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
@@ -77,7 +78,7 @@ func Test_runCmd(t *testing.T) {
 func Test_runCmdWithMultiTenancy(t *testing.T) {
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init command should not have returned an error")
+	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	stopChan = make(chan struct{})
@@ -107,7 +108,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		output := capturer.CaptureOutput(func() {
 			_, err := executeCommandC(
 				rootCmd, "run", "-c", "testdata/gatewayd.yaml", "-p", pluginTestConfigFile)
-			assert.NoError(t, err, "run command should not have returned an error")
+			require.NoError(t, err, "run command should not have returned an error")
 		})
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
@@ -125,7 +126,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	waitGroup.Wait()
 
 	// Clean up.
-	assert.NoError(t, os.Remove(pluginTestConfigFile))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
@@ -135,12 +136,12 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin init command should not have returned an error")
+	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	// Create a test config file.
 	_, err = executeCommandC(rootCmd, "config", "init", "--force", "-c", globalTestConfigFile)
-	assert.NoError(t, err, "configInitCmd should not return an error")
+	require.NoError(t, err, "configInitCmd should not return an error")
 	// Check that the config file was created.
 	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
@@ -149,7 +150,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		rootCmd, "plugin", "install",
 		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
 		"-p", pluginTestConfigFile, "--update")
-	assert.NoError(t, err, "plugin install should not return an error")
+	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll
 	assert.Contains(t, output, "Download completed successfully")
@@ -159,7 +160,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
-	assert.NoError(t, err, "plugin list should not return an error")
+	require.NoError(t, err, "plugin list should not return an error")
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
 	var waitGroup sync.WaitGroup
@@ -186,7 +187,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		// Test run command.
 		output := capturer.CaptureOutput(func() {
 			_, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
-			assert.NoError(t, err, "run command should not have returned an error")
+			require.NoError(t, err, "run command should not have returned an error")
 		})
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
@@ -206,7 +207,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	waitGroup.Wait()
 
 	// Clean up.
-	assert.NoError(t, os.RemoveAll("plugins/"))
-	assert.NoError(t, os.Remove(pluginTestConfigFile))
-	assert.NoError(t, os.Remove(globalTestConfigFile))
+	require.NoError(t, os.RemoveAll("plugins/"))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
+	require.NoError(t, os.Remove(globalTestConfigFile))
 }

--- a/cmd/test_plugins.yaml.bak
+++ b/cmd/test_plugins.yaml.bak
@@ -1,0 +1,10 @@
+acceptancePolicy: accept
+compatibilityPolicy: strict
+enableMetricsMerger: true
+healthCheckPeriod: 5s
+metricsMergerPeriod: 5s
+plugins: []
+reloadOnCrash: true
+terminationPolicy: stop
+timeout: 30s
+verificationPolicy: passdown

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -196,19 +197,17 @@ func listPlugins(cmd *cobra.Command, pluginConfigFile string, onlyEnabled bool) 
 	}
 }
 
-func extractZip(filename, dest string) []string {
+func extractZip(filename, dest string) ([]string, error) {
 	// Open and extract the zip file.
 	zipRc, err := zip.OpenReader(filename)
 	if err != nil {
-		if zipRc != nil {
-			zipRc.Close()
-		}
-		log.Panic("There was an error opening the downloaded plugin file: ", err)
+		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
+	defer zipRc.Close()
 
 	// Create the output directory if it doesn't exist.
 	if err := os.MkdirAll(dest, FolderPermissions); err != nil {
-		log.Panic("Failed to create directories: ", err)
+		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
 
 	// Extract the files.
@@ -223,7 +222,7 @@ func extractZip(filename, dest string) []string {
 				// Create the directory.
 
 				if err := os.MkdirAll(destPath, FolderPermissions); err != nil {
-					log.Panic("Failed to create directories: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			}
 		case fileInfo.Mode().IsRegular():
@@ -232,72 +231,68 @@ func extractZip(filename, dest string) []string {
 
 			// Check for ZipSlip.
 			if strings.HasPrefix(outFilename, string(os.PathSeparator)) {
-				log.Panic("Invalid file path in zip archive, aborting")
+				return nil, gerr.ErrExtractFailed.Wrap(
+					fmt.Errorf("illegal file path: %s", outFilename))
 			}
 
 			// Create the file.
 			outFile, err := os.Create(outFilename)
 			if err != nil {
-				log.Panic("Failed to create file: ", err)
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
+			defer outFile.Close()
 
 			// Open the file in the zip archive.
 			fileRc, err := file.Open()
 			if err != nil {
-				log.Panic("Failed to open file in zip archive: ", err)
+				os.Remove(outFilename)
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
 
 			// Copy the file contents.
 			if _, err := io.Copy(outFile, io.LimitReader(fileRc, MaxFileSize)); err != nil {
-				outFile.Close()
 				os.Remove(outFilename)
-				log.Panic("Failed to write to the file: ", err)
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
-			outFile.Close()
 
 			fileMode := file.FileInfo().Mode()
 			// Set the file permissions.
 			if fileMode.IsRegular() && fileMode&ExecFileMask != 0 {
 				if err := os.Chmod(outFilename, ExecFilePermissions); err != nil {
-					log.Panic("Failed to set executable file permissions: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			} else {
 				if err := os.Chmod(outFilename, FilePermissions); err != nil {
-					log.Panic("Failed to set file permissions: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			}
 
 			filenames = append(filenames, outFile.Name())
 		default:
-			log.Panicf("Failed to extract zip archive: unknown type: %s", file.Name)
+			return nil, gerr.ErrExtractFailed.Wrap(
+				fmt.Errorf("unknown file type: %s", file.Name))
 		}
 	}
 
-	if zipRc != nil {
-		zipRc.Close()
-	}
-
-	return filenames
+	return filenames, nil
 }
 
-func extractTarGz(filename, dest string) []string {
+func extractTarGz(filename, dest string) ([]string, error) {
 	// Open and extract the tar.gz file.
 	gzipStream, err := os.Open(filename)
 	if err != nil {
-		log.Panic("There was an error opening the downloaded plugin file: ", err)
+		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
+	defer gzipStream.Close()
 
 	uncompressedStream, err := gzip.NewReader(gzipStream)
 	if err != nil {
-		if gzipStream != nil {
-			gzipStream.Close()
-		}
-		log.Panic("Failed to extract tarball: ", err)
+		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
 
 	// Create the output directory if it doesn't exist.
 	if err := os.MkdirAll(dest, FolderPermissions); err != nil {
-		log.Panic("Failed to create directories: ", err)
+		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
 
 	tarReader := tar.NewReader(uncompressedStream)
@@ -311,7 +306,7 @@ func extractTarGz(filename, dest string) []string {
 		}
 
 		if err != nil {
-			log.Panic("Failed to extract tarball: ", err)
+			return nil, gerr.ErrExtractFailed.Wrap(err)
 		}
 
 		switch header.Typeflag {
@@ -322,7 +317,7 @@ func extractTarGz(filename, dest string) []string {
 			if !path.IsAbs(cleanPath) {
 				destPath := path.Join(dest, cleanPath)
 				if err := os.MkdirAll(destPath, FolderPermissions); err != nil {
-					log.Panic("Failed to create directories: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			}
 		case tar.TypeReg:
@@ -331,47 +326,41 @@ func extractTarGz(filename, dest string) []string {
 
 			// Check for TarSlip.
 			if strings.HasPrefix(outFilename, string(os.PathSeparator)) {
-				log.Panic("Invalid file path in tarball, aborting")
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
 
 			// Create the file.
 			outFile, err := os.Create(outFilename)
 			if err != nil {
-				log.Panic("Failed to create file: ", err)
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
+			defer outFile.Close()
+
 			if _, err := io.Copy(outFile, io.LimitReader(tarReader, MaxFileSize)); err != nil {
-				outFile.Close()
 				os.Remove(outFilename)
-				log.Panic("Failed to write to the file: ", err)
+				return nil, gerr.ErrExtractFailed.Wrap(err)
 			}
-			outFile.Close()
 
 			fileMode := header.FileInfo().Mode()
 			// Set the file permissions
 			if fileMode.IsRegular() && fileMode&ExecFileMask != 0 {
 				if err := os.Chmod(outFilename, ExecFilePermissions); err != nil {
-					log.Panic("Failed to set executable file permissions: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			} else {
 				if err := os.Chmod(outFilename, FilePermissions); err != nil {
-					log.Panic("Failed to set file permissions: ", err)
+					return nil, gerr.ErrExtractFailed.Wrap(err)
 				}
 			}
 
 			filenames = append(filenames, outFile.Name())
 		default:
-			log.Panicf(
-				"Failed to extract tarball: unknown type: %s in %s",
-				string(header.Typeflag),
-				header.Name)
+			return nil, gerr.ErrExtractFailed.Wrap(
+				fmt.Errorf("unknown file type: %s", header.Name))
 		}
 	}
 
-	if gzipStream != nil {
-		gzipStream.Close()
-	}
-
-	return filenames
+	return filenames, nil
 }
 
 func findAsset(release *github.RepositoryRelease, match func(string) bool) (string, string, int64) {
@@ -390,62 +379,58 @@ func findAsset(release *github.RepositoryRelease, match func(string) bool) (stri
 
 func downloadFile(
 	client *github.Client, account, pluginName string, releaseID int64, filename string,
-) string {
+) (string, error) {
 	// Download the plugin.
 	readCloser, redirectURL, err := client.Repositories.DownloadReleaseAsset(
 		context.Background(), account, pluginName, releaseID, http.DefaultClient)
 	if err != nil {
-		log.Panic("There was an error downloading the plugin: ", err)
+		return "", gerr.ErrDownloadFailed.Wrap(err)
 	}
+	defer readCloser.Close()
 
-	var reader io.ReadCloser
-	if readCloser != nil {
-		reader = readCloser
-		defer readCloser.Close()
-	} else if redirectURL != "" {
+	if redirectURL != "" {
 		// Download the plugin from the redirect URL.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirectURL, nil)
 		if err != nil {
-			log.Panic("There was an error downloading the plugin: ", err)
+			return "", gerr.ErrDownloadFailed.Wrap(err)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			log.Panic("There was an error downloading the plugin: ", err)
+			return "", gerr.ErrDownloadFailed.Wrap(err)
 		}
 		defer resp.Body.Close()
 
-		reader = resp.Body
+		readCloser = resp.Body
 	}
 
-	if reader != nil {
-		defer reader.Close()
-	} else {
-		log.Panic("The plugin could not be downloaded, please try again later")
+	if readCloser == nil {
+		return "", gerr.ErrDownloadFailed.Wrap(
+			fmt.Errorf("unable to download file: %s", filename))
 	}
 
 	// Create the output file in the current directory and write the downloaded content.
 	cwd, err := os.Getwd()
 	if err != nil {
-		log.Panic("There was an error downloading the plugin: ", err)
+		return "", gerr.ErrDownloadFailed.Wrap(err)
 	}
 	filePath := path.Join([]string{cwd, filename}...)
 	output, err := os.Create(filePath)
 	if err != nil {
-		log.Panic("There was an error downloading the plugin: ", err)
+		return "", gerr.ErrDownloadFailed.Wrap(err)
 	}
 	defer output.Close()
 
 	// Write the bytes to the file.
-	_, err = io.Copy(output, reader)
+	_, err = io.Copy(output, readCloser)
 	if err != nil {
-		log.Panic("There was an error downloading the plugin: ", err)
+		return "", gerr.ErrDownloadFailed.Wrap(err)
 	}
 
-	return filePath
+	return filePath, nil
 }
 
 // deleteFiles deletes the files in the toBeDeleted list.

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_versionCmd(t *testing.T) {
@@ -13,7 +14,7 @@ func Test_versionCmd(t *testing.T) {
 	config.Version = "SEMVER"
 	config.VersionDetails = "COMMIT-HASH"
 	output, err := executeCommandC(rootCmd, "version")
-	assert.NoError(t, err, "versionCmd should not return an error")
+	require.NoError(t, err, "versionCmd should not return an error")
 	assert.Regexp(t,
 		// The regexp matches something like the following output:
 		// GatewayD v0.7.7 (2023-09-16T19:27:38+0000/038f75b, go1.21.0, linux/amd64)

--- a/config/config.go
+++ b/config/config.go
@@ -22,13 +22,13 @@ import (
 )
 
 type IConfig interface {
-	InitConfig(context.Context)
-	LoadDefaults(context.Context)
-	LoadPluginEnvVars(context.Context)
-	LoadGlobalEnvVars(context.Context)
-	LoadGlobalConfigFile(context.Context)
-	LoadPluginConfigFile(context.Context)
-	MergeGlobalConfig(context.Context, map[string]interface{})
+	InitConfig(ctx context.Context)
+	LoadDefaults(ctx context.Context)
+	LoadPluginEnvVars(ctx context.Context)
+	LoadGlobalEnvVars(ctx context.Context)
+	LoadGlobalConfigFile(ctx context.Context)
+	LoadPluginConfigFile(ctx context.Context)
+	MergeGlobalConfig(ctx context.Context, updatedGlobalConfig map[string]interface{})
 }
 
 type Config struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,32 +8,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var parentDir = "../"
+
 // TestNewConfig tests the NewConfig function.
 func TestNewConfig(t *testing.T) {
 	config := NewConfig(
 		context.Background(), GlobalConfigFilename, PluginsConfigFilename)
 	assert.NotNil(t, config)
-	assert.Equal(t, config.globalConfigFile, GlobalConfigFilename)
-	assert.Equal(t, config.pluginConfigFile, PluginsConfigFilename)
-	assert.Equal(t, config.globalDefaults, GlobalConfig{})
-	assert.Equal(t, config.pluginDefaults, PluginConfig{})
-	assert.Equal(t, config.Global, GlobalConfig{})
-	assert.Equal(t, config.Plugin, PluginConfig{})
-	assert.Equal(t, config.GlobalKoanf, koanf.New("."))
-	assert.Equal(t, config.PluginKoanf, koanf.New("."))
+	assert.Equal(t, GlobalConfigFilename, config.globalConfigFile)
+	assert.Equal(t, PluginsConfigFilename, config.pluginConfigFile)
+	assert.Equal(t, GlobalConfig{}, config.globalDefaults)
+	assert.Equal(t, PluginConfig{}, config.pluginDefaults)
+	assert.Equal(t, GlobalConfig{}, config.Global)
+	assert.Equal(t, PluginConfig{}, config.Plugin)
+	assert.Equal(t, koanf.New("."), config.GlobalKoanf)
+	assert.Equal(t, koanf.New("."), config.PluginKoanf)
 }
 
 // TestInitConfig tests the InitConfig function, which practically tests all
 // the other functions.
 func TestInitConfig(t *testing.T) {
 	ctx := context.Background()
-	config := NewConfig(ctx, "../"+GlobalConfigFilename, "../"+PluginsConfigFilename)
+	config := NewConfig(ctx, parentDir+GlobalConfigFilename, parentDir+PluginsConfigFilename)
 	config.InitConfig(ctx)
 	assert.NotNil(t, config.Global)
-	assert.NotEqual(t, config.Global, GlobalConfig{})
+	assert.NotEqual(t, GlobalConfig{}, config.Global)
 	assert.Contains(t, config.Global.Servers, Default)
 	assert.NotNil(t, config.Plugin)
-	assert.NotEqual(t, config.Plugin, PluginConfig{})
+	assert.NotEqual(t, PluginConfig{}, config.Plugin)
 	assert.Len(t, config.Plugin.Plugins, 1)
 	assert.NotNil(t, config.GlobalKoanf)
 	assert.NotEqual(t, config.GlobalKoanf, koanf.New("."))
@@ -42,20 +44,20 @@ func TestInitConfig(t *testing.T) {
 	assert.NotEqual(t, config.PluginKoanf, koanf.New("."))
 	assert.Equal(t, string(PassDown), config.PluginKoanf.String("verificationPolicy"))
 	assert.NotNil(t, config.globalDefaults)
-	assert.NotEqual(t, config.globalDefaults, GlobalConfig{})
+	assert.NotEqual(t, GlobalConfig{}, config.globalDefaults)
 	assert.Contains(t, config.globalDefaults.Servers, Default)
 	assert.NotNil(t, config.pluginDefaults)
-	assert.NotEqual(t, config.pluginDefaults, PluginConfig{})
-	assert.Len(t, config.pluginDefaults.Plugins, 0)
+	assert.NotEqual(t, PluginConfig{}, config.pluginDefaults)
+	assert.Empty(t, config.pluginDefaults.Plugins)
 }
 
 // TestMergeGlobalConfig tests the MergeGlobalConfig function.
 func TestMergeGlobalConfig(t *testing.T) {
 	ctx := context.Background()
-	config := NewConfig(ctx, "../"+GlobalConfigFilename, "../"+PluginsConfigFilename)
+	config := NewConfig(ctx, parentDir+GlobalConfigFilename, parentDir+PluginsConfigFilename)
 	config.InitConfig(ctx)
 	// The default log level is info.
-	assert.Equal(t, config.Global.Loggers[Default].Level, DefaultLogLevel)
+	assert.Equal(t, DefaultLogLevel, config.Global.Loggers[Default].Level)
 
 	// Merge a config that sets the log level to debug.
 	config.MergeGlobalConfig(ctx, map[string]interface{}{
@@ -66,7 +68,7 @@ func TestMergeGlobalConfig(t *testing.T) {
 		},
 	})
 	assert.NotNil(t, config.Global)
-	assert.NotEqual(t, config.Global, GlobalConfig{})
+	assert.NotEqual(t, GlobalConfig{}, config.Global)
 	// The log level should now be debug.
-	assert.Equal(t, config.Global.Loggers[Default].Level, "debug")
+	assert.Equal(t, "debug", config.Global.Loggers[Default].Level)
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -37,6 +37,8 @@ const (
 	ErrCodeInvalidMetricType
 	ErrCodeValidationFailed
 	ErrCodeLintingFailed
+	ErrCodeExtractFailed
+	ErrCodeDownloadFailed
 )
 
 var (
@@ -120,6 +122,11 @@ var (
 		ErrCodeValidationFailed, "validation failed", nil)
 	ErrLintingFailed = NewGatewayDError(
 		ErrCodeLintingFailed, "linting failed", nil)
+
+	ErrExtractFailed = NewGatewayDError(
+		ErrCodeExtractFailed, "failed to extract the archive", nil)
+	ErrDownloadFailed = NewGatewayDError(
+		ErrCodeDownloadFailed, "failed to download the file", nil)
 )
 
 const (
@@ -128,4 +135,5 @@ const (
 	FailedToCreateClient     = 3
 	FailedToInitializePool   = 4
 	FailedToStartServer      = 5
+	FailedToStartTracer      = 6
 )

--- a/errors/gatewayd_error_test.go
+++ b/errors/gatewayd_error_test.go
@@ -5,19 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewGatewayDError tests the creation of a new GatewayDError.
 func TestNewGatewayDError(t *testing.T) {
 	err := NewGatewayDError(ErrCodeUnknown, "test", nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Code, ErrCodeUnknown)
-	assert.Equal(t, err.Error(), "test")
-	assert.Equal(t, err.Message, "test")
-	assert.Nil(t, err.OriginalError)
+	assert.Equal(t, ErrCodeUnknown, err.Code)
+	assert.Equal(t, "test", err.Error())
+	assert.Equal(t, "test", err.Message)
+	require.NoError(t, err.OriginalError)
 
 	assert.NotNil(t, err.Wrap(io.EOF))
-	assert.Equal(t, err.OriginalError, io.EOF)
+	assert.Equal(t, io.EOF, err.OriginalError)
 	assert.Equal(t, io.EOF, err.Unwrap())
-	assert.Equal(t, err.Error(), "test, OriginalError: EOF")
+	assert.Equal(t, "test, OriginalError: EOF", err.Error())
 }

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -56,7 +56,7 @@ func TestNewLogger_File(t *testing.T) {
 	logger.Error().Str("key", "value").Msg("This is an error")
 
 	f, err := os.ReadFile("gatewayd.log")
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	assert.NotEmpty(t, f)
 	assert.Contains(t, string(f), "This is an error")
 	os.Remove("gatewayd.log")

--- a/metrics/merger.go
+++ b/metrics/merger.go
@@ -181,9 +181,9 @@ func (m *Merger) MergeMetrics(pluginMetrics map[string][]byte) *gerr.GatewayDErr
 		// Add plugin label to each metric.
 		metricFamilies := map[string]*promClient.MetricFamily{}
 		for _, metric := range metrics {
-			for _, sample := range metric.Metric {
+			for _, sample := range metric.GetMetric() {
 				// Add plugin label to each metric.
-				sample.Label = append(sample.Label, &promClient.LabelPair{
+				sample.Label = append(sample.GetLabel(), &promClient.LabelPair{
 					Name:  proto.String("plugin"),
 					Value: proto.String(strings.ReplaceAll(pluginName, "-", "_")),
 				})

--- a/network/client.go
+++ b/network/client.go
@@ -118,7 +118,7 @@ func NewClient(ctx context.Context, clientConfig *config.Client, logger zerolog.
 			logger.Error().Err(err).Msg("Failed to set receive deadline")
 			span.RecordError(err)
 		} else {
-			logger.Debug().Str("duration", fmt.Sprint(client.ReceiveDeadline.String())).Msg(
+			logger.Debug().Str("duration", client.ReceiveDeadline.String()).Msg(
 				"Set receive deadline")
 		}
 	}

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/logging"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // CreateNewClient creates a new client for testing.
@@ -61,7 +62,7 @@ func TestSend(t *testing.T) {
 	packet := CreatePostgreSQLPacket('Q', []byte("select 1;"))
 	sent, err := client.Send(packet)
 	assert.Nil(t, err)
-	assert.Equal(t, len(packet), sent)
+	assert.Len(t, packet, sent)
 }
 
 // TestReceive tests the Receive function.
@@ -73,13 +74,13 @@ func TestReceive(t *testing.T) {
 	packet := CreatePgStartupPacket()
 	sent, err := client.Send(packet)
 	assert.Nil(t, err)
-	assert.Equal(t, len(packet), sent)
+	assert.Len(t, packet, sent)
 
 	size, data, err := client.Receive()
 	// AuthenticationSASL
 	msg := "\x00\x00\x00\nSCRAM-SHA-256\x00\x00"
 	assert.Equal(t, 24, size)
-	assert.Equal(t, len(data[:size]), size)
+	assert.Len(t, data[:size], size)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, data[:size])
 	assert.Equal(t, msg, string(data[5:size]))
@@ -118,7 +119,7 @@ func TestReconnect(t *testing.T) {
 	localAddr := client.LocalAddr()
 	assert.NotEmpty(t, localAddr)
 
-	assert.NoError(t, client.Reconnect())
+	require.NoError(t, client.Reconnect())
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.conn)
 	assert.NotEmpty(t, client.ID)

--- a/network/engine_test.go
+++ b/network/engine_test.go
@@ -34,7 +34,7 @@ func TestEngine(t *testing.T) {
 			v := <-engine.stopServer
 			// Empty struct is expected to be received and
 			// it means that the server is stopped.
-			assert.Equal(t, v, struct{}{})
+			assert.Equal(t, struct{}{}, v)
 		}(engine)
 
 		err := engine.Stop(context.Background())

--- a/network/network_helpers_test.go
+++ b/network/network_helpers_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type WriteBuffer struct {
@@ -146,6 +146,6 @@ func CollectAndComparePrometheusMetrics(t *testing.T) {
 			"gatewayd_server_ticks_fired_total",
 		}
 	)
-	assert.NoError(t,
+	require.NoError(t,
 		testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(want), metrics...))
 }

--- a/network/proxy_test.go
+++ b/network/proxy_test.go
@@ -68,9 +68,9 @@ func TestNewProxy(t *testing.T) {
 	if c, ok := proxy.availableConnections.Pop(client.ID).(*Client); ok {
 		assert.NotEqual(t, "", c.ID)
 	}
-	assert.Equal(t, false, proxy.Elastic)
-	assert.Equal(t, false, proxy.ReuseElasticClients)
-	assert.Equal(t, false, proxy.IsExhausted())
+	assert.False(t, proxy.Elastic)
+	assert.False(t, proxy.ReuseElasticClients)
+	assert.False(t, proxy.IsExhausted())
 	c, err := proxy.IsHealthy(client)
 	assert.Nil(t, err)
 	assert.Equal(t, client, c)
@@ -121,8 +121,8 @@ func TestNewProxyElastic(t *testing.T) {
 	assert.NotNil(t, proxy)
 	assert.Equal(t, 0, proxy.busyConnections.Size())
 	assert.Equal(t, 0, proxy.availableConnections.Size())
-	assert.Equal(t, true, proxy.Elastic)
-	assert.Equal(t, false, proxy.ReuseElasticClients)
+	assert.True(t, proxy.Elastic)
+	assert.False(t, proxy.ReuseElasticClients)
 	assert.Equal(t, "tcp", proxy.ClientConfig.Network)
 	assert.Equal(t, "localhost:5432", proxy.ClientConfig.Address)
 }

--- a/network/server.go
+++ b/network/server.go
@@ -341,7 +341,7 @@ func (s *Server) OnTick() (time.Duration, Action) {
 	defer span.End()
 
 	s.logger.Debug().Msg("GatewayD is ticking...")
-	s.logger.Info().Str("count", fmt.Sprint(s.engine.CountConnections())).Msg(
+	s.logger.Info().Str("count", strconv.Itoa(s.engine.CountConnections())).Msg(
 		"Active client connections")
 
 	pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), s.pluginTimeout)
@@ -371,7 +371,7 @@ func (s *Server) Run() *gerr.GatewayDError {
 	_, span := otel.Tracer("gatewayd").Start(s.ctx, "Run")
 	defer span.End()
 
-	s.logger.Info().Str("pid", fmt.Sprint(os.Getpid())).Msg("GatewayD is running")
+	s.logger.Info().Str("pid", strconv.Itoa(os.Getpid())).Msg("GatewayD is running")
 
 	// Try to resolve the address and log an error if it can't be resolved
 	addr, err := Resolve(s.Network, s.Address, s.logger)

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -209,15 +210,15 @@ func TestRunServer(t *testing.T) {
 				// Read the log file and check if the log file contains the expected log messages.
 				if _, err := os.Stat("server_test.log"); err == nil {
 					logFile, err := os.Open("server_test.log")
-					assert.NoError(t, err)
+					assert.Nil(t, err)
 
 					reader := bufio.NewReader(logFile)
 					assert.NotNil(t, reader)
 
 					buffer, err := io.ReadAll(reader)
-					assert.NoError(t, err)
-					assert.Greater(t, len(buffer), 0) // The log file should not be empty.
-					assert.NoError(t, logFile.Close())
+					assert.Nil(t, err)
+					assert.NotEmpty(t, buffer) // The log file should not be empty.
+					require.NoError(t, logFile.Close())
 
 					logLines := string(buffer)
 					assert.Contains(t, logLines, "GatewayD is running", "GatewayD should be running")
@@ -226,7 +227,7 @@ func TestRunServer(t *testing.T) {
 					assert.Contains(t, logLines, "Egress traffic", "Egress traffic should be logged")
 					assert.Contains(t, logLines, "GatewayD is shutting down", "GatewayD should be shutting down")
 
-					assert.NoError(t, os.Remove("server_test.log"))
+					require.NoError(t, os.Remove("server_test.log"))
 				}
 				waitGroup.Done()
 				return
@@ -274,7 +275,7 @@ func TestRunServer(t *testing.T) {
 				assert.NotNil(t, client)
 				sent, err := client.Send(CreatePgStartupPacket())
 				assert.Nil(t, err)
-				assert.Equal(t, len(CreatePgStartupPacket()), sent)
+				assert.Len(t, CreatePgStartupPacket(), sent)
 
 				// The server should respond with an 'R' packet.
 				size, data, err := client.Receive()
@@ -284,7 +285,7 @@ func TestRunServer(t *testing.T) {
 				}
 				// This includes the message type, length and the message itself.
 				assert.Equal(t, 24, size)
-				assert.Equal(t, len(data[:size]), size)
+				assert.Len(t, data[:size], size)
 				assert.Nil(t, err)
 				packetSize := int(data[1])<<24 | int(data[2])<<16 | int(data[3])<<8 | int(data[4])
 				assert.Equal(t, 23, packetSize)

--- a/plugin/plugin_registry.go
+++ b/plugin/plugin_registry.go
@@ -340,7 +340,7 @@ func (reg *Registry) Run(
 			if reg.Termination == config.Stop {
 				// If the terminate flag is set to true,
 				// abort the execution of the rest of the registered hooks.
-				if terminate, ok := result.Fields["terminate"]; ok && terminate.GetBoolValue() {
+				if terminate, ok := result.GetFields()["terminate"]; ok && terminate.GetBoolValue() {
 					break
 				}
 			}
@@ -522,7 +522,7 @@ func (reg *Registry) LoadPlugins(ctx context.Context, plugins []config.Plugin) {
 		span.AddEvent("Fetched plugin metadata")
 
 		// Retrieve plugin requirements.
-		if requires, ok := metadata.Fields["requires"]; ok && requires != nil && requires.GetListValue() != nil {
+		if requires, ok := metadata.GetFields()["requires"]; ok && requires != nil && requires.GetListValue() != nil {
 			if err := mapstructure.Decode(
 				requires.GetListValue().AsSlice(), &plugin.Requires); err != nil {
 				reg.Logger.Debug().Err(err).Msg("Failed to decode plugin requirements")
@@ -567,14 +567,14 @@ func (reg *Registry) LoadPlugins(ctx context.Context, plugins []config.Plugin) {
 
 		span.AddEvent("Verified plugin requirements")
 
-		plugin.ID.RemoteURL = metadata.Fields["id"].GetStructValue().Fields["remoteUrl"].GetStringValue()
-		plugin.ID.Version = metadata.Fields["id"].GetStructValue().Fields["version"].GetStringValue()
-		plugin.Description = metadata.Fields["description"].GetStringValue()
-		plugin.License = metadata.Fields["license"].GetStringValue()
-		plugin.ProjectURL = metadata.Fields["projectUrl"].GetStringValue()
+		plugin.ID.RemoteURL = metadata.GetFields()["id"].GetStructValue().GetFields()["remoteUrl"].GetStringValue()
+		plugin.ID.Version = metadata.GetFields()["id"].GetStructValue().GetFields()["version"].GetStringValue()
+		plugin.Description = metadata.GetFields()["description"].GetStringValue()
+		plugin.License = metadata.GetFields()["license"].GetStringValue()
+		plugin.ProjectURL = metadata.GetFields()["projectUrl"].GetStringValue()
 		// Retrieve authors.
-		if metadata.Fields["authors"] != nil && metadata.Fields["authors"].GetListValue() != nil {
-			if err := mapstructure.Decode(metadata.Fields["authors"].GetListValue().AsSlice(),
+		if metadata.GetFields()["authors"] != nil && metadata.GetFields()["authors"].GetListValue() != nil {
+			if err := mapstructure.Decode(metadata.GetFields()["authors"].GetListValue().AsSlice(),
 				&plugin.Authors); err != nil {
 				reg.Logger.Debug().Err(err).Msg("Failed to decode plugin authors")
 			}
@@ -584,8 +584,8 @@ func (reg *Registry) LoadPlugins(ctx context.Context, plugins []config.Plugin) {
 		}
 
 		// Retrieve hooks.
-		if metadata.Fields["hooks"] != nil && metadata.Fields["hooks"].GetListValue() != nil {
-			if err := mapstructure.Decode(metadata.Fields["hooks"].GetListValue().AsSlice(),
+		if metadata.GetFields()["hooks"] != nil && metadata.GetFields()["hooks"].GetListValue() != nil {
+			if err := mapstructure.Decode(metadata.GetFields()["hooks"].GetListValue().AsSlice(),
 				&plugin.Hooks); err != nil {
 				reg.Logger.Debug().Err(err).Msg("Failed to decode plugin hooks")
 			}
@@ -596,8 +596,8 @@ func (reg *Registry) LoadPlugins(ctx context.Context, plugins []config.Plugin) {
 
 		// Retrieve plugin config.
 		plugin.Config = make(map[string]string)
-		if metadata.Fields["config"] != nil && metadata.Fields["config"].GetStructValue() != nil {
-			for key, value := range metadata.Fields["config"].GetStructValue().AsMap() {
+		if metadata.GetFields()["config"] != nil && metadata.GetFields()["config"].GetStructValue() != nil {
+			for key, value := range metadata.GetFields()["config"].GetStructValue().AsMap() {
 				if val, ok := value.(string); ok {
 					plugin.Config[key] = val
 				} else {

--- a/plugin/plugin_registry_test.go
+++ b/plugin/plugin_registry_test.go
@@ -43,7 +43,7 @@ func TestPluginRegistry(t *testing.T) {
 	assert.NotNil(t, reg)
 	assert.NotNil(t, reg.plugins)
 	assert.NotNil(t, reg.hooks)
-	assert.Equal(t, 0, len(reg.List()))
+	assert.Empty(t, reg.List())
 
 	ident := sdkPlugin.Identifier{
 		Name:      "test",
@@ -54,13 +54,13 @@ func TestPluginRegistry(t *testing.T) {
 		ID: ident,
 	}
 	reg.Add(impl)
-	assert.Equal(t, 1, len(reg.List()))
+	assert.Len(t, reg.List(), 1)
 
 	instance := reg.Get(ident)
 	assert.Equal(t, instance, impl)
 
 	reg.Remove(ident)
-	assert.Equal(t, 0, len(reg.List()))
+	assert.Empty(t, reg.List())
 
 	reg.Shutdown()
 }
@@ -291,7 +291,7 @@ func Test_HookRegistry_Run_Remove(t *testing.T) {
 	result, err := reg.Run(context.Background(), map[string]interface{}{}, v1.HookName_HOOK_NAME_ON_NEW_LOGGER)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{}, result)
-	assert.Equal(t, 1, len(reg.Hooks()[v1.HookName_HOOK_NAME_ON_NEW_LOGGER]))
+	assert.Len(t, reg.Hooks()[v1.HookName_HOOK_NAME_ON_NEW_LOGGER], 1)
 }
 
 func BenchmarkHookRun(b *testing.B) {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -12,7 +12,7 @@ import (
 type Callback func(key, value interface{}) bool
 
 type IPool interface {
-	ForEach(Callback)
+	ForEach(cb Callback)
 	Pool() *sync.Map
 	Put(key, value interface{}) *gerr.GatewayDError
 	Get(key interface{}) interface{}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -48,13 +48,13 @@ func TestPool_Pop(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, pool.Size())
 	if c1, ok := pool.Pop("client1.ID").(string); !ok {
-		assert.Equal(t, c1, "client1")
+		assert.Equal(t, "client1", c1)
 	} else {
 		assert.Equal(t, "client1", c1)
 		assert.Equal(t, 1, pool.Size())
 	}
 	if c2, ok := pool.Pop("client2.ID").(string); !ok {
-		assert.Equal(t, c2, "client2")
+		assert.Equal(t, "client2", c2)
 	} else {
 		assert.Equal(t, "client2", c2)
 		assert.Equal(t, 0, pool.Size())
@@ -115,13 +115,13 @@ func TestPool_Get(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, pool.Size())
 	if c1, ok := pool.Get("client1.ID").(string); !ok {
-		assert.Equal(t, c1, "client1")
+		assert.Equal(t, "client1", c1)
 	} else {
 		assert.Equal(t, "client1", c1)
 		assert.Equal(t, 2, pool.Size())
 	}
 	if c2, ok := pool.Get("client2.ID").(string); !ok {
-		assert.Equal(t, c2, "client2")
+		assert.Equal(t, "client2", c2)
 	} else {
 		assert.Equal(t, "client2", c2)
 		assert.Equal(t, 2, pool.Size())
@@ -144,7 +144,7 @@ func TestPool_GetOrPut(t *testing.T) {
 	c1, loaded, err := pool.GetOrPut("client1.ID", "client1")
 	assert.True(t, loaded)
 	if c1, ok := c1.(string); !ok {
-		assert.Equal(t, c1, "client1")
+		assert.Equal(t, "client1", c1)
 	} else {
 		assert.Equal(t, "client1", c1)
 		assert.Equal(t, 2, pool.Size())
@@ -153,7 +153,7 @@ func TestPool_GetOrPut(t *testing.T) {
 	c2, loaded, err := pool.GetOrPut("client2.ID", "client2")
 	assert.True(t, loaded)
 	if c2, ok := c2.(string); !ok {
-		assert.Equal(t, c2, "client2")
+		assert.Equal(t, "client2", c2)
 	} else {
 		assert.Equal(t, "client2", c2)
 		assert.Equal(t, 2, pool.Size())
@@ -201,7 +201,7 @@ func TestPool_GetClientIDs(t *testing.T) {
 		}
 		return true
 	})
-	assert.Equal(t, 2, len(ids))
+	assert.Len(t, ids, 2)
 	assert.Contains(t, ids, "client1.ID")
 	assert.Contains(t, ids, "client2.ID")
 	pool.Clear()


### PR DESCRIPTION
# Ticket(s)
- #348 

## Description
This PR removes all instances of the `log.Panic` in the `cmd` package and replaces them with a print and return.

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
