### PR TITLE
add group name to log

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -237,6 +237,7 @@ var runCmd = &cobra.Command{
 				SyslogPriority: cfg.GetSyslogPriority(),
 				RSyslogNetwork: cfg.RSyslogNetwork,
 				RSyslogAddress: cfg.RSyslogAddress,
+				Name:           name,
 			})
 		}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -147,8 +147,8 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
 		assert.Contains(t, output, "GatewayD is running")
-		assert.Contains(t, output, "There are clients available in the pool count=10 group=default name=default")
-		assert.Contains(t, output, "There are clients available in the pool count=10 group=test name=test")
+		assert.Contains(t, output, "There are clients available in the pool count=10 group=default")
+		assert.Contains(t, output, "There are clients available in the pool count=10 group=test")
 		assert.Contains(t, output, "GatewayD is listening address=0.0.0.0:15432")
 		assert.Contains(t, output, "GatewayD is listening address=0.0.0.0:15433")
 		assert.Contains(t, output, "Stopped all servers")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -38,7 +38,7 @@ func Test_runCmd(t *testing.T) {
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
 		assert.Contains(t, output, "GatewayD is running")
-		assert.Contains(t, output, "Stopped all servers\n")
+		assert.Contains(t, output, "Stopped all servers")
 
 		waitGroup.Done()
 	}(&waitGroup)
@@ -94,7 +94,7 @@ func Test_runCmdWithTLS(t *testing.T) {
 		// Check if GatewayD started and stopped correctly.
 		assert.Contains(t, output, "GatewayD is running")
 		assert.Contains(t, output, "TLS is enabled")
-		assert.Contains(t, output, "Stopped all servers\n")
+		assert.Contains(t, output, "Stopped all servers")
 
 		waitGroup.Done()
 	}(&waitGroup)
@@ -147,11 +147,11 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
 		assert.Contains(t, output, "GatewayD is running")
-		assert.Contains(t, output, "There are clients available in the pool count=10 name=default")
-		assert.Contains(t, output, "There are clients available in the pool count=10 name=test")
+		assert.Contains(t, output, "There are clients available in the pool count=10 group=default name=default")
+		assert.Contains(t, output, "There are clients available in the pool count=10 group=test name=test")
 		assert.Contains(t, output, "GatewayD is listening address=0.0.0.0:15432")
 		assert.Contains(t, output, "GatewayD is listening address=0.0.0.0:15433")
-		assert.Contains(t, output, "Stopped all servers\n")
+		assert.Contains(t, output, "Stopped all servers")
 
 		waitGroup.Done()
 	}(&waitGroup)
@@ -227,7 +227,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
 		assert.Contains(t, output, "GatewayD is running")
-		assert.Contains(t, output, "Stopped all servers\n")
+		assert.Contains(t, output, "Stopped all servers")
 
 		waitGroup.Done()
 	}(&waitGroup)

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -99,7 +99,7 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 	multiWriter := zerolog.MultiLevelWriter(outputs...)
 	logger := zerolog.New(multiWriter)
 	logger = logger.With().Timestamp().Logger()
-	logger = logger.With().Any("group", cfg.Name).Logger()
+	logger = logger.With().Str("group", cfg.Name).Logger()
 
 	span.End()
 

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -35,6 +35,9 @@ type LoggerConfig struct {
 	MaxAge     int
 	Compress   bool
 	LocalTime  bool
+
+	// group name
+	Name string
 }
 
 // NewLogger creates a new logger with the given configuration.
@@ -96,6 +99,7 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 	multiWriter := zerolog.MultiLevelWriter(outputs...)
 	logger := zerolog.New(multiWriter)
 	logger = logger.With().Timestamp().Logger()
+	logger = logger.With().Any("group", cfg.Name).Logger()
 
 	span.End()
 


### PR DESCRIPTION
# Ticket(s)
related to #339 
## Description
by using some functionalities in zerolog, one can add some custom tags to all log lines. e.g. `group=default/test/etc`

## Related PRs

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
