### PR TITLE
Add group name to Windows logger

### DIFF
--- a/logging/logger_windows.go
+++ b/logging/logger_windows.go
@@ -34,6 +34,9 @@ type LoggerConfig struct {
 	MaxAge     int
 	Compress   bool
 	LocalTime  bool
+
+	// group name
+	Name string
 }
 
 // NewLogger creates a new logger with the given configuration.
@@ -82,6 +85,7 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 	multiWriter := zerolog.MultiLevelWriter(outputs...)
 	logger := zerolog.New(multiWriter)
 	logger = logger.With().Timestamp().Logger()
+	logger = logger.With().Str("group", cfg.Name).Logger()
 
 	span.End()
 


### PR DESCRIPTION
# Ticket(s)
- #339 

## Description
This adds group name to the Windows-specific logger.

## Related PRs
- #394
- https://github.com/gatewayd-io/docs/pull/37

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [ ] I have squashed related commits together.
- [ ] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
