### PR TITLE
Automate plugin installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Run Go tests 🔬
         run: go test -p 1 -cover -covermode atomic -coverprofile=profile.cov -v ./...
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.INTEGRATION }}
 
       - name: Report coverage to coveralls 📈
         uses: shogo82148/actions-goveralls@v1

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ dist/
 libtensorflow*
 
 # Test generated files
-cmd/test_plugins.yaml.bak
+cmd/test_*.yaml.bak
+cmd/test_*.yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,8 @@ linters-settings:
           - "github.com/getsentry/sentry-go"
           - "github.com/rs/zerolog"
           - "github.com/grpc-ecosystem/grpc-gateway"
+          - "google.golang.org/grpc"
+          - "google.golang.org/protobuf"
           - "github.com/knadh/koanf"
           - "github.com/panjf2000/gnet/v2"
           - "github.com/spf13/cobra"
@@ -62,6 +64,10 @@ linters-settings:
           - "github.com/google/go-github/v53/github"
           - "github.com/codingsince1985/checksum"
           - "golang.org/x/exp/maps"
+          - "golang.org/x/exp/slices"
+          - "gopkg.in/yaml.v3"
+          - "github.com/zenizh/go-capturer"
+          - "gopkg.in/natefinch/lumberjack.v2"
       test:
         files:
           - $test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,7 @@ linters-settings:
           - "github.com/knadh/koanf"
           - "github.com/panjf2000/gnet/v2"
           - "github.com/spf13/cobra"
+          - "github.com/spf13/cast"
           - "github.com/invopop/jsonschema"
           - "github.com/santhosh-tekuri/jsonschema/v5"
           - "github.com/NYTimes/gziphandler"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,6 +61,7 @@ linters-settings:
           - "github.com/google/go-cmp"
           - "github.com/google/go-github/v53/github"
           - "github.com/codingsince1985/checksum"
+          - "golang.org/x/exp/maps"
       test:
         files:
           - $test

--- a/cmd/cmd_helpers_test.go
+++ b/cmd/cmd_helpers_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	globalTestConfigFile    = "./test_global.yaml"
-	globalTLSTestConfigFile = "./testdata/gatewayd_tls.yaml"
-	pluginTestConfigFile    = "./test_plugins.yaml"
-)
-
 // executeCommandC executes a cobra command and returns the command, output, and error.
 // Taken from https://github.com/spf13/cobra/blob/0c72800b8dba637092b57a955ecee75949e79a73/command_test.go#L48.
 func executeCommandC(root *cobra.Command, args ...string) (string, error) {

--- a/cmd/cmd_helpers_test.go
+++ b/cmd/cmd_helpers_test.go
@@ -33,5 +33,5 @@ func mustPullPlugin() (string, error) {
 		}
 	}
 
-	return filepath.Abs(fileName)
+	return filepath.Abs(fileName) //nolint:wrapcheck
 }

--- a/cmd/cmd_helpers_test.go
+++ b/cmd/cmd_helpers_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -17,4 +19,19 @@ func executeCommandC(root *cobra.Command, args ...string) (string, error) {
 	_, err := root.ExecuteC()
 
 	return buf.String(), err
+}
+
+// mustPullPlugin pulls the gatewayd-plugin-cache plugin and returns the path to the archive.
+func mustPullPlugin() (string, error) {
+	pluginURL := "github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.10"
+	fileName := "./gatewayd-plugin-cache-linux-amd64-v0.2.10.tar.gz"
+
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		_, err := executeCommandC(rootCmd, "plugin", "install", "--pull-only", pluginURL)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return filepath.Abs(fileName)
 }

--- a/cmd/config_init_test.go
+++ b/cmd/config_init_test.go
@@ -22,7 +22,7 @@ func Test_configInitCmd(t *testing.T) {
 	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
 	// Test configInitCmd with the --force flag to overwrite the config file.
-	output, err = executeCommandC(rootCmd, "config", "init", "--force")
+	output, err = executeCommandC(rootCmd, "config", "init", "--force", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was overwritten successfully.", globalTestConfigFile),

--- a/cmd/config_init_test.go
+++ b/cmd/config_init_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_configInitCmd(t *testing.T) {
+	globalTestConfigFile := "./test_global_configInitCmd.yaml"
 	// Test configInitCmd.
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")

--- a/cmd/config_lint_test.go
+++ b/cmd/config_lint_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_configLintCmd(t *testing.T) {
+	globalTestConfigFile := "./test_global_configLintCmd.yaml"
 	// Test configInitCmd.
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")

--- a/cmd/plugin_init_test.go
+++ b/cmd/plugin_init_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_pluginInitCmd(t *testing.T) {
+	pluginTestConfigFile := "./test_plugins_pluginInitCmd.yaml"
 	// Test plugin init command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -50,7 +50,7 @@ var (
 var pluginInstallCmd = &cobra.Command{
 	Use:     "install",
 	Short:   "Install a plugin from a local archive or a GitHub repository",
-	Example: "  gatewayd plugin install github.com/gatewayd-io/gatewayd-plugin-cache@latest",
+	Example: "  gatewayd plugin install <github.com/gatewayd-io/gatewayd-plugin-cache@latest|/path/to/plugin[.zip|.tar.gz]>", //nolint:lll
 	Run: func(cmd *cobra.Command, args []string) {
 		// Enable Sentry.
 		if enableSentry {

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -202,9 +202,9 @@ func init() {
 	pluginInstallCmd.Flags().BoolVar(
 		&backupConfig, "backup", false, "Backup the plugins configuration file before installing the plugin")
 	pluginInstallCmd.Flags().StringVarP(
-		&pluginName, "name", "n", "", "Name of the plugin")
+		&pluginName, "name", "n", "", "Name of the plugin (only for installing from archive files)")
 	pluginInstallCmd.Flags().BoolVar(
-		&overwriteConfig, "overwrite-config", true, "Overwrite the existing plugins configuration file")
+		&overwriteConfig, "overwrite-config", true, "Overwrite the existing plugins configuration file (overrides --update, only used for installing from the plugins configuration file)") //nolint:lll
 	pluginInstallCmd.Flags().BoolVar(
 		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -43,6 +43,7 @@ var (
 	backupConfig    bool
 	noPrompt        bool
 	pluginName      string
+	overwriteConfig bool
 )
 
 // pluginInstallCmd represents the plugin install command.
@@ -202,6 +203,8 @@ func init() {
 		&backupConfig, "backup", false, "Backup the plugins configuration file before installing the plugin")
 	pluginInstallCmd.Flags().StringVarP(
 		&pluginName, "name", "n", "", "Name of the plugin")
+	pluginInstallCmd.Flags().BoolVar(
+		&overwriteConfig, "overwrite-config", true, "Overwrite the existing plugins configuration file")
 	pluginInstallCmd.Flags().BoolVar(
 		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -1,20 +1,12 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"regexp"
-	"runtime"
-	"slices"
-	"strings"
 
-	"github.com/codingsince1985/checksum"
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/getsentry/sentry-go"
-	"github.com/google/go-github/v53/github"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -45,9 +37,6 @@ var pluginInstallCmd = &cobra.Command{
 	Short:   "Install a plugin from a local archive or a GitHub repository",
 	Example: "  gatewayd plugin install github.com/gatewayd-io/gatewayd-plugin-cache@latest",
 	Run: func(cmd *cobra.Command, args []string) {
-		// This is a list of files that will be deleted after the plugin is installed.
-		toBeDeleted := []string{}
-
 		// Enable Sentry.
 		if enableSentry {
 			// Initialize Sentry.
@@ -65,199 +54,6 @@ var pluginInstallCmd = &cobra.Command{
 			defer sentry.Flush(config.DefaultFlushTimeout)
 			// Recover from panics and report the error to Sentry.
 			defer sentry.Recover()
-		}
-
-		// Validate the number of arguments.
-		if len(args) < 1 {
-			cmd.Println(
-				"Invalid URL. Use the following format: github.com/account/repository@version")
-			return
-		}
-
-		var releaseID int64
-		var downloadURL string
-		var pluginFilename string
-		var pluginName string
-		var err error
-		var checksumsFilename string
-		var client *github.Client
-		var account string
-
-		// Strip scheme from the plugin URL.
-		args[0] = strings.TrimPrefix(args[0], "http://")
-		args[0] = strings.TrimPrefix(args[0], "https://")
-
-		if !strings.HasPrefix(args[0], GitHubURLPrefix) {
-			// Pull the plugin from a local archive.
-			pluginFilename = filepath.Clean(args[0])
-			if _, err := os.Stat(pluginFilename); os.IsNotExist(err) {
-				cmd.Println("The plugin file could not be found")
-				return
-			}
-		}
-
-		// Validate the URL.
-		validGitHubURL := regexp.MustCompile(GitHubURLRegex)
-		if !validGitHubURL.MatchString(args[0]) {
-			cmd.Println(
-				"Invalid URL. Use the following format: github.com/account/repository@version")
-			return
-		}
-
-		// Get the plugin version.
-		pluginVersion := LatestVersion
-		splittedURL := strings.Split(args[0], "@")
-		// If the version is not specified, use the latest version.
-		if len(splittedURL) < NumParts {
-			cmd.Println("Version not specified. Using latest version")
-		}
-		if len(splittedURL) >= NumParts {
-			pluginVersion = splittedURL[1]
-		}
-
-		// Get the plugin account and repository.
-		accountRepo := strings.Split(strings.TrimPrefix(splittedURL[0], GitHubURLPrefix), "/")
-		if len(accountRepo) != NumParts {
-			cmd.Println(
-				"Invalid URL. Use the following format: github.com/account/repository@version")
-			return
-		}
-		account = accountRepo[0]
-		pluginName = accountRepo[1]
-		if account == "" || pluginName == "" {
-			cmd.Println(
-				"Invalid URL. Use the following format: github.com/account/repository@version")
-			return
-		}
-
-		// Get the release artifact from GitHub.
-		client = github.NewClient(nil)
-		var release *github.RepositoryRelease
-
-		if pluginVersion == LatestVersion || pluginVersion == "" {
-			// Get the latest release.
-			release, _, err = client.Repositories.GetLatestRelease(
-				context.Background(), account, pluginName)
-		} else if strings.HasPrefix(pluginVersion, "v") {
-			// Get an specific release.
-			release, _, err = client.Repositories.GetReleaseByTag(
-				context.Background(), account, pluginName, pluginVersion)
-		}
-
-		if err != nil {
-			cmd.Println("The plugin could not be found: ", err.Error())
-			return
-		}
-
-		if release == nil {
-			cmd.Println("The plugin could not be found in the release assets")
-			return
-		}
-
-		// Get the archive extension.
-		archiveExt := ExtOthers
-		if runtime.GOOS == "windows" {
-			archiveExt = ExtWindows
-		}
-
-		// Find and download the plugin binary from the release assets.
-		pluginFilename, downloadURL, releaseID = findAsset(release, func(name string) bool {
-			return strings.Contains(name, runtime.GOOS) &&
-				strings.Contains(name, runtime.GOARCH) &&
-				strings.Contains(name, archiveExt)
-		})
-
-		var filePath string
-		if downloadURL != "" && releaseID != 0 {
-			cmd.Println("Downloading", downloadURL)
-			filePath, err = downloadFile(client, account, pluginName, releaseID, pluginFilename)
-			toBeDeleted = append(toBeDeleted, filePath)
-			if err != nil {
-				cmd.Println("Download failed: ", err)
-				if cleanup {
-					deleteFiles(toBeDeleted)
-				}
-				return
-			}
-			cmd.Println("Download completed successfully")
-		} else {
-			cmd.Println("The plugin file could not be found in the release assets")
-			return
-		}
-
-		// Find and download the checksums.txt from the release assets.
-		checksumsFilename, downloadURL, releaseID = findAsset(release, func(name string) bool {
-			return strings.Contains(name, "checksums.txt")
-		})
-		if checksumsFilename != "" && downloadURL != "" && releaseID != 0 {
-			cmd.Println("Downloading", downloadURL)
-			filePath, err = downloadFile(client, account, pluginName, releaseID, checksumsFilename)
-			toBeDeleted = append(toBeDeleted, filePath)
-			if err != nil {
-				cmd.Println("Download failed: ", err)
-				if cleanup {
-					deleteFiles(toBeDeleted)
-				}
-				return
-			}
-			cmd.Println("Download completed successfully")
-		} else {
-			cmd.Println("The checksum file could not be found in the release assets")
-			return
-		}
-
-		// Read the checksums text file.
-		checksums, err := os.ReadFile(checksumsFilename)
-		if err != nil {
-			cmd.Println("There was an error reading the checksums file: ", err)
-			return
-		}
-
-		// Get the checksum for the plugin binary.
-		sum, err := checksum.SHA256sum(pluginFilename)
-		if err != nil {
-			cmd.Println("There was an error calculating the checksum: ", err)
-			return
-		}
-
-		// Verify the checksums.
-		checksumLines := strings.Split(string(checksums), "\n")
-		for _, line := range checksumLines {
-			if strings.Contains(line, pluginFilename) {
-				checksum := strings.Split(line, " ")[0]
-				if checksum != sum {
-					cmd.Println("Checksum verification failed")
-					return
-				}
-
-				cmd.Println("Checksum verification passed")
-				break
-			}
-		}
-
-		if pullOnly {
-			cmd.Println("Plugin binary downloaded to", pluginFilename)
-			// Only the checksums file will be deleted if the --pull-only flag is set.
-			if err := os.Remove(checksumsFilename); err != nil {
-				cmd.Println("There was an error deleting the file: ", err)
-			}
-			return
-		}
-
-		// Create a new gatewayd_plugins.yaml file if it doesn't exist.
-		if _, err := os.Stat(pluginConfigFile); os.IsNotExist(err) {
-			generateConfig(cmd, Plugins, pluginConfigFile, false)
-		} else {
-			// If the config file exists, we should prompt the user to backup
-			// the plugins configuration file.
-			if !backupConfig && !noPrompt {
-				cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
-				var backupOption string
-				_, err := fmt.Scanln(&backupOption)
-				if err == nil && (backupOption == "y" || backupOption == "Y") {
-					backupConfig = true
-				}
-			}
 		}
 
 		// Read the gatewayd_plugins.yaml file.
@@ -279,180 +75,36 @@ var pluginInstallCmd = &cobra.Command{
 			return
 		}
 
-		// Check if the plugin is already installed.
+		// Get the list of plugin download URLs.
+		var pluginURLs []string
 		for _, plugin := range pluginsList {
-			// User already chosen to update the plugin using the --update CLI flag.
-			if update {
-				break
-			}
-
 			if pluginInstance, ok := plugin.(map[string]interface{}); ok {
-				if pluginInstance["name"] == pluginName {
-					// Show a list of options to the user.
-					cmd.Println("Plugin is already installed.")
-					if !noPrompt {
-						cmd.Print("Do you want to update the plugin? [y/N] ")
-
-						var updateOption string
-						_, err := fmt.Scanln(&updateOption)
-						if err == nil && (updateOption == "y" || updateOption == "Y") {
-							break
-						}
-					}
-
-					cmd.Println("Aborting...")
-					if cleanup {
-						deleteFiles(toBeDeleted)
-					}
-					return
+				// Get the plugin URL.
+				url := cast.ToString(pluginInstance["url"])
+				if url != "" {
+					pluginURLs = append(pluginURLs, url)
 				}
 			}
 		}
 
-		// Check if the user wants to take a backup of the plugins configuration file.
-		if backupConfig {
-			backupFilename := fmt.Sprintf("%s.bak", pluginConfigFile)
-			if err := os.WriteFile(backupFilename, pluginsConfig, FilePermissions); err != nil {
-				cmd.Println("There was an error backing up the plugins configuration file: ", err)
-			}
-			cmd.Println("Backup completed successfully")
+		// Validate the number of arguments.
+		if len(args) < 1 && len(pluginURLs) < 1 {
+			cmd.Println(
+				"Invalid URL. Use the following format: github.com/account/repository@version")
+			return
 		}
 
-		// Extract the archive.
-		var filenames []string
-		if runtime.GOOS == "windows" {
-			filenames, err = extractZip(pluginFilename, pluginOutputDir)
+		if len(args) > 0 {
+			// Install the plugin from the CLI argument.
+			cmd.Println("Installing plugin from CLI argument")
+			installPlugin(cmd, args[0])
 		} else {
-			filenames, err = extractTarGz(pluginFilename, pluginOutputDir)
-		}
-
-		if err != nil {
-			cmd.Println("There was an error extracting the plugin archive: ", err)
-			if cleanup {
-				deleteFiles(toBeDeleted)
-			}
-			return
-		}
-
-		// Delete all the files except the extracted plugin binary,
-		// which will be deleted from the list further down.
-		toBeDeleted = append(toBeDeleted, filenames...)
-
-		// Find the extracted plugin binary.
-		localPath := ""
-		pluginFileSum := ""
-		for _, filename := range filenames {
-			if strings.Contains(filename, pluginName) {
-				cmd.Println("Plugin binary extracted to", filename)
-
-				// Remove the plugin binary from the list of files to be deleted.
-				toBeDeleted = slices.DeleteFunc[[]string, string](toBeDeleted, func(s string) bool {
-					return s == filename
-				})
-
-				localPath = filename
-				// Get the checksum for the extracted plugin binary.
-				// TODO: Should we verify the checksum using the checksum.txt file instead?
-				pluginFileSum, err = checksum.SHA256sum(filename)
-				if err != nil {
-					cmd.Println("There was an error calculating the checksum: ", err)
-					return
-				}
-				break
+			// Install all the plugins from the plugins configuration file.
+			cmd.Println("Installing plugins from plugins configuration file")
+			for _, pluginURL := range pluginURLs {
+				installPlugin(cmd, pluginURL)
 			}
 		}
-
-		var contents string
-		if strings.HasPrefix(args[0], GitHubURLPrefix) {
-			// Get the list of files in the repository.
-			var repoContents *github.RepositoryContent
-			repoContents, _, _, err = client.Repositories.GetContents(
-				context.Background(), account, pluginName, DefaultPluginConfigFilename, nil)
-			if err != nil {
-				cmd.Println(
-					"There was an error getting the default plugins configuration file: ", err)
-				return
-			}
-			// Get the contents of the file.
-			contents, err = repoContents.GetContent()
-			if err != nil {
-				cmd.Println(
-					"There was an error getting the default plugins configuration file: ", err)
-				return
-			}
-		} else {
-			// Get the contents of the file.
-			contentsBytes, err := os.ReadFile(
-				filepath.Join(pluginOutputDir, DefaultPluginConfigFilename))
-			if err != nil {
-				cmd.Println(
-					"There was an error getting the default plugins configuration file: ", err)
-				return
-			}
-			contents = string(contentsBytes)
-		}
-
-		// Get the plugin configuration from the downloaded plugins configuration file.
-		var downloadedPluginConfig map[string]interface{}
-		if err := yamlv3.Unmarshal([]byte(contents), &downloadedPluginConfig); err != nil {
-			cmd.Println("Failed to unmarshal the downloaded plugins configuration file: ", err)
-			return
-		}
-		defaultPluginConfig, ok := downloadedPluginConfig["plugins"].([]interface{})
-		if !ok {
-			cmd.Println("There was an error reading the plugins file from the repository")
-			return
-		}
-		// Get the plugin configuration.
-		pluginConfig, ok := defaultPluginConfig[0].(map[string]interface{})
-		if !ok {
-			cmd.Println("There was an error reading the default plugin configuration")
-			return
-		}
-
-		// Update the plugin's local path and checksum.
-		pluginConfig["localPath"] = localPath
-		pluginConfig["checksum"] = pluginFileSum
-
-		// Add the plugin config to the list of plugin configs.
-		added := false
-		for idx, plugin := range pluginsList {
-			if pluginInstance, ok := plugin.(map[string]interface{}); ok {
-				if pluginInstance["name"] == pluginName {
-					pluginsList[idx] = pluginConfig
-					added = true
-					break
-				}
-			}
-		}
-		if !added {
-			pluginsList = append(pluginsList, pluginConfig)
-		}
-
-		// Merge the result back into the config map.
-		localPluginsConfig["plugins"] = pluginsList
-
-		// Marshal the map into YAML.
-		updatedPlugins, err := yamlv3.Marshal(localPluginsConfig)
-		if err != nil {
-			cmd.Println("There was an error marshalling the plugins configuration: ", err)
-			return
-		}
-
-		// Write the YAML to the plugins config file.
-		if err = os.WriteFile(pluginConfigFile, updatedPlugins, FilePermissions); err != nil {
-			cmd.Println("There was an error writing the plugins configuration file: ", err)
-			return
-		}
-
-		// Delete the downloaded and extracted files, except the plugin binary,
-		// if the --cleanup flag is set.
-		if cleanup {
-			deleteFiles(toBeDeleted)
-		}
-
-		// TODO: Add a rollback mechanism.
-		cmd.Println("Plugin installed successfully")
 	},
 }
 

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -132,11 +132,11 @@ var pluginInstallCmd = &cobra.Command{
 						cmd.Println("Use the --update flag to update the plugins")
 						cmd.Println("Aborting...")
 						return
-					} else {
-						// Merge the existing plugin URLs with the plugin URLs.
-						for name, url := range existingPluginURLs {
-							pluginURLs[name] = url
-						}
+					}
+
+					// Merge the existing plugin URLs with the plugin URLs.
+					for name, url := range existingPluginURLs {
+						pluginURLs[name] = url
 					}
 				} else {
 					cmd.Print("Do you want to update the existing plugins? [y/N] ")

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -21,18 +21,17 @@ func Test_pluginInstallCmd(t *testing.T) {
 		"plugin init command should have returned the correct output")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
+	// Pull the plugin archive and install it.
+	pluginArchivePath, err = mustPullPlugin()
+	require.NoError(t, err, "mustPullPlugin should not return an error")
+	assert.FileExists(t, pluginArchivePath, "mustPullPlugin should have downloaded the plugin archive")
+
 	// Test plugin install command.
 	output, err = executeCommandC(
-		rootCmd, "plugin", "install",
-		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
-		"-p", pluginTestConfigFile, "--update", "--backup")
+		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
+		"--update", "--backup", "--name", "gatewayd-plugin-cache", pluginArchivePath)
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll
-	assert.Contains(t, output, "Download completed successfully")
-	assert.Contains(t, output, "Checksum verification passed")
-	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
-	assert.Contains(t, output, "Plugin installed successfully")
+	assert.Equal(t, output, "Installing plugin from CLI argument\nBackup completed successfully\nPlugin binary extracted to plugins/gatewayd-plugin-cache\nPlugin installed successfully\n") //nolint:lll
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_pluginInstallCmd(t *testing.T) {
+	pluginTestConfigFile := "./test_plugins_pluginInstallCmd.yaml"
+
 	// Create a test plugin config file.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init should not return an error")
@@ -53,12 +55,12 @@ func Test_pluginInstallCmd(t *testing.T) {
 }
 
 func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
-	pluginTestConfig := "testdata/gatewayd_plugins.yaml"
+	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
 
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",
-		"-p", pluginTestConfig, "--update", "--backup", "--overwrite-config=false")
+		"-p", pluginTestConfigFile, "--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "/gatewayd-plugin-cache-linux-amd64-")
 	assert.Contains(t, output, "/checksums.txt")
@@ -68,18 +70,18 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	assert.Contains(t, output, "Plugin installed successfully")
 
 	// See if the plugin was actually installed.
-	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfig)
+	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list should not return an error")
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
 	// Clean up.
 	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
-	assert.FileExists(t, fmt.Sprintf("%s.bak", pluginTestConfig))
+	assert.FileExists(t, fmt.Sprintf("%s.bak", pluginTestConfigFile))
 	assert.NoFileExists(t, "plugins/LICENSE")
 	assert.NoFileExists(t, "plugins/README.md")
 	assert.NoFileExists(t, "plugins/checksum.txt")
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfig)))
+	require.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfigFile)))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -56,6 +56,9 @@ func Test_pluginInstallCmd(t *testing.T) {
 func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
 
+	// Reset the global variable.
+	pullOnly = false
+
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",

--- a/cmd/plugin_list_test.go
+++ b/cmd/plugin_list_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_pluginListCmd(t *testing.T) {
+	pluginTestConfigFile := "./test_plugins_pluginListCmd.yaml"
 	// Test plugin list command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -178,8 +178,8 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
-	globalTestConfigFile := "./test_global_runCmdWithCachePlugin.yaml"
-	pluginTestConfigFile := "./test_plugins_runCmdWithCachePlugin.yaml"
+	globalTestConfigFile := "test_global_runCmdWithCachePlugin.yaml"
+	pluginTestConfigFile := "test_plugins_runCmdWithCachePlugin.yaml"
 	// TODO: Remove this once these global variables are removed from cmd/run.go.
 	// https://github.com/gatewayd-io/gatewayd/issues/324
 	stopChan = make(chan struct{})
@@ -209,6 +209,8 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	assert.Contains(t, output, "Checksum verification passed")
 	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
 	assert.Contains(t, output, "Plugin installed successfully")
+
+	require.FileExists(t, pluginTestConfigFile, "plugin install command should have created a config file")
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -129,7 +129,7 @@ func Test_runCmdWithTLS(t *testing.T) {
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
 // Note: This test needs two instances of PostgreSQL running on ports 5432 and 5433.
 func Test_runCmdWithMultiTenancy(t *testing.T) {
-	globalTestConfigFile := "testdata/gatewayd.yaml"
+	globalTestConfigFile := "./testdata/gatewayd.yaml"
 	pluginTestConfigFile := "./test_plugins_runCmdWithMultiTenancy.yaml"
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -66,10 +65,6 @@ func Test_runCmd(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
-
-	// Clean up.
-	require.NoError(t, os.Remove(pluginTestConfigFile))
-	require.NoError(t, os.Remove(globalTestConfigFile))
 }
 
 // Test_runCmdWithTLS tests the run command with TLS enabled on the server.
@@ -124,9 +119,6 @@ func Test_runCmdWithTLS(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
-
-	// Clean up.
-	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
@@ -183,9 +175,6 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
-
-	// Clean up.
-	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
@@ -263,9 +252,4 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
-
-	// Clean up.
-	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginTestConfigFile))
-	require.NoError(t, os.Remove(globalTestConfigFile))
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -199,11 +199,13 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",
-		"github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.4",
+		"github.com/gatewayd-io/gatewayd-plugin-cache@latest",
 		"-p", pluginTestConfigFile, "--update")
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz") //nolint:lll
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.2.4/checksums.txt")                                   //nolint:lll
+	assert.Contains(t, output, "Installing plugin from CLI argument")
+	assert.Contains(t, output, "Downloading ")
+	assert.Contains(t, output, "gatewayd-plugin-cache-linux-amd64-")
+	assert.Contains(t, output, "/checksums.txt")
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")
 	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -70,6 +72,9 @@ func Test_runCmd(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
+
+	require.NoError(t, os.Remove(globalTestConfigFile))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 // Test_runCmdWithTLS tests the run command with TLS enabled on the server.
@@ -124,6 +129,8 @@ func Test_runCmdWithTLS(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
+
+	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
@@ -180,6 +187,8 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
+
+	require.NoError(t, os.Remove(pluginTestConfigFile))
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
@@ -256,4 +265,9 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	}(&waitGroup)
 
 	waitGroup.Wait()
+
+	require.NoError(t, os.RemoveAll("plugins/"))
+	require.NoError(t, os.Remove(globalTestConfigFile))
+	require.NoError(t, os.Remove(pluginTestConfigFile))
+	require.NoError(t, os.Remove(fmt.Sprintf("%s.bak", pluginTestConfigFile)))
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -208,7 +208,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile, "--update", "--backup",
-		"--name", "gatewayd-plugin-cache", pluginArchivePath)
+		"--overwrite-config=true", "--name", "gatewayd-plugin-cache", pluginArchivePath)
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Equal(t, output, "Installing plugin from CLI argument\nBackup completed successfully\nPlugin binary extracted to plugins/gatewayd-plugin-cache\nPlugin installed successfully\n") //nolint:lll
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -198,8 +198,8 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	// Test plugin install command.
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",
-		"github.com/gatewayd-io/gatewayd-plugin-cache@latest",
-		"-p", pluginTestConfigFile, "--update")
+		"-p", pluginTestConfigFile, "--update",
+		"github.com/gatewayd-io/gatewayd-plugin-cache@latest")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugin from CLI argument")
 	assert.Contains(t, output, "Downloading ")
@@ -235,7 +235,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(waitBeforeStop)
+		time.Sleep(waitBeforeStop * 2)
 
 		StopGracefully(
 			context.Background(),

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -13,7 +13,11 @@ import (
 	"github.com/zenizh/go-capturer"
 )
 
+var waitBeforeStop = time.Second
+
 func Test_runCmd(t *testing.T) {
+	globalTestConfigFile := "./test_global_runCmd.yaml"
+	pluginTestConfigFile := "./test_plugins_runCmd.yaml"
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
@@ -45,7 +49,7 @@ func Test_runCmd(t *testing.T) {
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(waitBeforeStop)
 
 		StopGracefully(
 			context.Background(),
@@ -70,6 +74,8 @@ func Test_runCmd(t *testing.T) {
 
 // Test_runCmdWithTLS tests the run command with TLS enabled on the server.
 func Test_runCmdWithTLS(t *testing.T) {
+	globalTLSTestConfigFile := "./testdata/gatewayd_tls.yaml"
+	pluginTestConfigFile := "./test_plugins_runCmdWithTLS.yaml"
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
@@ -101,7 +107,7 @@ func Test_runCmdWithTLS(t *testing.T) {
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(waitBeforeStop)
 
 		StopGracefully(
 			context.Background(),
@@ -126,6 +132,8 @@ func Test_runCmdWithTLS(t *testing.T) {
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
 // Note: This test needs two instances of PostgreSQL running on ports 5432 and 5433.
 func Test_runCmdWithMultiTenancy(t *testing.T) {
+	globalTestConfigFile := "testdata/gatewayd.yaml"
+	pluginTestConfigFile := "./test_plugins_runCmdWithMultiTenancy.yaml"
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
@@ -140,7 +148,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		// Test run command.
 		output := capturer.CaptureOutput(func() {
 			_, err := executeCommandC(
-				rootCmd, "run", "-c", "testdata/gatewayd.yaml", "-p", pluginTestConfigFile)
+				rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
 			require.NoError(t, err, "run command should not have returned an error")
 		})
 		// Print the output for debugging purposes.
@@ -158,7 +166,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(waitBeforeStop)
 
 		StopGracefully(
 			context.Background(),
@@ -181,6 +189,8 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
+	globalTestConfigFile := "./test_global_runCmdWithCachePlugin.yaml"
+	pluginTestConfigFile := "./test_plugins_runCmdWithCachePlugin.yaml"
 	// TODO: Remove this once these global variables are removed from cmd/run.go.
 	// https://github.com/gatewayd-io/gatewayd/issues/324
 	stopChan = make(chan struct{})
@@ -236,7 +246,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(time.Second)
+		time.Sleep(waitBeforeStop)
 
 		StopGracefully(
 			context.Background(),

--- a/cmd/testdata/gatewayd_plugins.yaml
+++ b/cmd/testdata/gatewayd_plugins.yaml
@@ -1,0 +1,21 @@
+plugins:
+  - name: gatewayd-plugin-cache
+    enabled: True
+    url: github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.10
+    localPath: plugins/gatewayd-plugin-cache
+    args: ["--log-level", "debug"]
+    env:
+      - MAGIC_COOKIE_KEY=GATEWAYD_PLUGIN
+      - MAGIC_COOKIE_VALUE=5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872
+      - REDIS_URL=redis://localhost:6379/0
+      - EXPIRY=1h
+      - METRICS_ENABLED=True
+      - METRICS_UNIX_DOMAIN_SOCKET=/tmp/gatewayd-plugin-cache.sock
+      - METRICS_PATH=/metrics
+      - PERIODIC_INVALIDATOR_ENABLED=True
+      - PERIODIC_INVALIDATOR_INTERVAL=1m
+      - PERIODIC_INVALIDATOR_START_DELAY=1m
+      - API_ADDRESS=localhost:18080
+      - EXIT_ON_STARTUP_ERROR=False
+      - SENTRY_DSN=https://70eb1abcd32e41acbdfc17bc3407a543@o4504550475038720.ingest.sentry.io/4505342961123328
+    checksum: 867e09326da10b6e321d8dbcfcf2d20835bde79a82edc2b440dd81d151041672

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -14,8 +14,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
 	"strings"
 
+	"github.com/codingsince1985/checksum"
 	"github.com/gatewayd-io/gatewayd/config"
 	gerr "github.com/gatewayd-io/gatewayd/errors"
 	"github.com/google/go-github/v53/github"
@@ -25,6 +29,7 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	jsonSchemaV5 "github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/spf13/cobra"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 type (
@@ -441,4 +446,401 @@ func deleteFiles(toBeDeleted []string) {
 			return
 		}
 	}
+}
+
+// installPlugin installs a plugin from a given URL.
+func installPlugin(cmd *cobra.Command, pluginURL string) {
+	// This is a list of files that will be deleted after the plugin is installed.
+	toBeDeleted := []string{}
+
+	var (
+		releaseID         int64
+		downloadURL       string
+		pluginFilename    string
+		pluginName        string
+		err               error
+		checksumsFilename string
+		client            *github.Client
+		account           string
+	)
+
+	// Strip scheme from the plugin URL.
+	pluginURL = strings.TrimPrefix(pluginURL, "http://")
+	pluginURL = strings.TrimPrefix(pluginURL, "https://")
+
+	if !strings.HasPrefix(pluginURL, GitHubURLPrefix) {
+		// Pull the plugin from a local archive.
+		pluginFilename = filepath.Clean(pluginURL)
+		if _, err := os.Stat(pluginFilename); os.IsNotExist(err) {
+			cmd.Println("The plugin file could not be found")
+			return
+		}
+	}
+
+	// Validate the URL.
+	splittedURL := strings.Split(pluginURL, "@")
+	if len(splittedURL) < NumParts {
+		if pluginFilename == "" {
+			// If the version is not specified, use the latest version.
+			pluginURL = fmt.Sprintf("%s@%s", pluginURL, LatestVersion)
+		}
+	}
+
+	validGitHubURL := regexp.MustCompile(GitHubURLRegex)
+	if !validGitHubURL.MatchString(pluginURL) {
+		cmd.Println(
+			"Invalid URL. Use the following format: github.com/account/repository@version")
+		return
+	}
+
+	// Get the plugin version.
+	pluginVersion := LatestVersion
+	splittedURL = strings.Split(pluginURL, "@")
+	// If the version is not specified, use the latest version.
+	if len(splittedURL) < NumParts {
+		cmd.Println("Version not specified. Using latest version")
+	}
+	if len(splittedURL) >= NumParts {
+		pluginVersion = splittedURL[1]
+	}
+
+	// Get the plugin account and repository.
+	accountRepo := strings.Split(strings.TrimPrefix(splittedURL[0], GitHubURLPrefix), "/")
+	if len(accountRepo) != NumParts {
+		cmd.Println(
+			"Invalid URL. Use the following format: github.com/account/repository@version")
+		return
+	}
+	account = accountRepo[0]
+	pluginName = accountRepo[1]
+	if account == "" || pluginName == "" {
+		cmd.Println(
+			"Invalid URL. Use the following format: github.com/account/repository@version")
+		return
+	}
+
+	// Get the release artifact from GitHub.
+	client = github.NewClient(nil)
+	var release *github.RepositoryRelease
+
+	if pluginVersion == LatestVersion || pluginVersion == "" {
+		// Get the latest release.
+		release, _, err = client.Repositories.GetLatestRelease(
+			context.Background(), account, pluginName)
+	} else if strings.HasPrefix(pluginVersion, "v") {
+		// Get an specific release.
+		release, _, err = client.Repositories.GetReleaseByTag(
+			context.Background(), account, pluginName, pluginVersion)
+	}
+
+	if err != nil {
+		cmd.Println("The plugin could not be found: ", err.Error())
+		return
+	}
+
+	if release == nil {
+		cmd.Println("The plugin could not be found in the release assets")
+		return
+	}
+
+	// Get the archive extension.
+	archiveExt := ExtOthers
+	if runtime.GOOS == "windows" {
+		archiveExt = ExtWindows
+	}
+
+	// Find and download the plugin binary from the release assets.
+	pluginFilename, downloadURL, releaseID = findAsset(release, func(name string) bool {
+		return strings.Contains(name, runtime.GOOS) &&
+			strings.Contains(name, runtime.GOARCH) &&
+			strings.Contains(name, archiveExt)
+	})
+
+	var filePath string
+	if downloadURL != "" && releaseID != 0 {
+		cmd.Println("Downloading", downloadURL)
+		filePath, err = downloadFile(client, account, pluginName, releaseID, pluginFilename)
+		toBeDeleted = append(toBeDeleted, filePath)
+		if err != nil {
+			cmd.Println("Download failed: ", err)
+			if cleanup {
+				deleteFiles(toBeDeleted)
+			}
+			return
+		}
+		cmd.Println("Download completed successfully")
+	} else {
+		cmd.Println("The plugin file could not be found in the release assets")
+		return
+	}
+
+	// Find and download the checksums.txt from the release assets.
+	checksumsFilename, downloadURL, releaseID = findAsset(release, func(name string) bool {
+		return strings.Contains(name, "checksums.txt")
+	})
+	if checksumsFilename != "" && downloadURL != "" && releaseID != 0 {
+		cmd.Println("Downloading", downloadURL)
+		filePath, err = downloadFile(client, account, pluginName, releaseID, checksumsFilename)
+		toBeDeleted = append(toBeDeleted, filePath)
+		if err != nil {
+			cmd.Println("Download failed: ", err)
+			if cleanup {
+				deleteFiles(toBeDeleted)
+			}
+			return
+		}
+		cmd.Println("Download completed successfully")
+	} else {
+		cmd.Println("The checksum file could not be found in the release assets")
+		return
+	}
+
+	// Read the checksums text file.
+	checksums, err := os.ReadFile(checksumsFilename)
+	if err != nil {
+		cmd.Println("There was an error reading the checksums file: ", err)
+		return
+	}
+
+	// Get the checksum for the plugin binary.
+	sum, err := checksum.SHA256sum(pluginFilename)
+	if err != nil {
+		cmd.Println("There was an error calculating the checksum: ", err)
+		return
+	}
+
+	// Verify the checksums.
+	checksumLines := strings.Split(string(checksums), "\n")
+	for _, line := range checksumLines {
+		if strings.Contains(line, pluginFilename) {
+			checksum := strings.Split(line, " ")[0]
+			if checksum != sum {
+				cmd.Println("Checksum verification failed")
+				return
+			}
+
+			cmd.Println("Checksum verification passed")
+			break
+		}
+	}
+
+	if pullOnly {
+		cmd.Println("Plugin binary downloaded to", pluginFilename)
+		// Only the checksums file will be deleted if the --pull-only flag is set.
+		if err := os.Remove(checksumsFilename); err != nil {
+			cmd.Println("There was an error deleting the file: ", err)
+		}
+		return
+	}
+
+	// Create a new gatewayd_plugins.yaml file if it doesn't exist.
+	if _, err := os.Stat(pluginConfigFile); os.IsNotExist(err) {
+		generateConfig(cmd, Plugins, pluginConfigFile, false)
+	} else {
+		// If the config file exists, we should prompt the user to backup
+		// the plugins configuration file.
+		if !backupConfig && !noPrompt {
+			cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
+			var backupOption string
+			_, err := fmt.Scanln(&backupOption)
+			if err == nil && (backupOption == "y" || backupOption == "Y") {
+				backupConfig = true
+			}
+		}
+	}
+
+	// Read the gatewayd_plugins.yaml file.
+	pluginsConfig, err := os.ReadFile(pluginConfigFile)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	// Get the registered plugins from the plugins configuration file.
+	var localPluginsConfig map[string]interface{}
+	if err := yamlv3.Unmarshal(pluginsConfig, &localPluginsConfig); err != nil {
+		log.Println("Failed to unmarshal the plugins configuration file: ", err)
+		return
+	}
+	pluginsList, ok := localPluginsConfig["plugins"].([]interface{}) //nolint:varnamelen
+	if !ok {
+		log.Println("There was an error reading the plugins file from disk")
+		return
+	}
+
+	// Check if the plugin is already installed.
+	for _, plugin := range pluginsList {
+		// User already chosen to update the plugin using the --update CLI flag.
+		if update {
+			break
+		}
+
+		//nolint:nestif
+		if pluginInstance, ok := plugin.(map[string]interface{}); ok {
+			if pluginInstance["name"] == pluginName {
+				// Show a list of options to the user.
+				cmd.Println("Plugin is already installed.")
+				if !noPrompt {
+					cmd.Print("Do you want to update the plugin? [y/N] ")
+
+					var updateOption string
+					_, err := fmt.Scanln(&updateOption)
+					if err == nil && (updateOption == "y" || updateOption == "Y") {
+						break
+					}
+				}
+
+				cmd.Println("Aborting...")
+				if cleanup {
+					deleteFiles(toBeDeleted)
+				}
+				return
+			}
+		}
+	}
+
+	// Check if the user wants to take a backup of the plugins configuration file.
+	if backupConfig {
+		backupFilename := fmt.Sprintf("%s.bak", pluginConfigFile)
+		if err := os.WriteFile(backupFilename, pluginsConfig, FilePermissions); err != nil {
+			cmd.Println("There was an error backing up the plugins configuration file: ", err)
+		}
+		cmd.Println("Backup completed successfully")
+	}
+
+	// Extract the archive.
+	var filenames []string
+	if runtime.GOOS == "windows" {
+		filenames, err = extractZip(pluginFilename, pluginOutputDir)
+	} else {
+		filenames, err = extractTarGz(pluginFilename, pluginOutputDir)
+	}
+
+	if err != nil {
+		cmd.Println("There was an error extracting the plugin archive: ", err)
+		if cleanup {
+			deleteFiles(toBeDeleted)
+		}
+		return
+	}
+
+	// Delete all the files except the extracted plugin binary,
+	// which will be deleted from the list further down.
+	toBeDeleted = append(toBeDeleted, filenames...)
+
+	// Find the extracted plugin binary.
+	localPath := ""
+	pluginFileSum := ""
+	for _, filename := range filenames {
+		if strings.Contains(filename, pluginName) {
+			cmd.Println("Plugin binary extracted to", filename)
+
+			// Remove the plugin binary from the list of files to be deleted.
+			toBeDeleted = slices.DeleteFunc[[]string, string](toBeDeleted, func(s string) bool {
+				return s == filename
+			})
+
+			localPath = filename
+			// Get the checksum for the extracted plugin binary.
+			// TODO: Should we verify the checksum using the checksum.txt file instead?
+			pluginFileSum, err = checksum.SHA256sum(filename)
+			if err != nil {
+				cmd.Println("There was an error calculating the checksum: ", err)
+				return
+			}
+			break
+		}
+	}
+
+	var contents string
+	if strings.HasPrefix(pluginURL, GitHubURLPrefix) {
+		// Get the list of files in the repository.
+		var repoContents *github.RepositoryContent
+		repoContents, _, _, err = client.Repositories.GetContents(
+			context.Background(), account, pluginName, DefaultPluginConfigFilename, nil)
+		if err != nil {
+			cmd.Println(
+				"There was an error getting the default plugins configuration file: ", err)
+			return
+		}
+		// Get the contents of the file.
+		contents, err = repoContents.GetContent()
+		if err != nil {
+			cmd.Println(
+				"There was an error getting the default plugins configuration file: ", err)
+			return
+		}
+	} else {
+		// Get the contents of the file.
+		contentsBytes, err := os.ReadFile(
+			filepath.Join(pluginOutputDir, DefaultPluginConfigFilename))
+		if err != nil {
+			cmd.Println(
+				"There was an error getting the default plugins configuration file: ", err)
+			return
+		}
+		contents = string(contentsBytes)
+	}
+
+	// Get the plugin configuration from the downloaded plugins configuration file.
+	var downloadedPluginConfig map[string]interface{}
+	if err := yamlv3.Unmarshal([]byte(contents), &downloadedPluginConfig); err != nil {
+		cmd.Println("Failed to unmarshal the downloaded plugins configuration file: ", err)
+		return
+	}
+	defaultPluginConfig, ok := downloadedPluginConfig["plugins"].([]interface{})
+	if !ok {
+		cmd.Println("There was an error reading the plugins file from the repository")
+		return
+	}
+	// Get the plugin configuration.
+	pluginConfig, ok := defaultPluginConfig[0].(map[string]interface{})
+	if !ok {
+		cmd.Println("There was an error reading the default plugin configuration")
+		return
+	}
+
+	// Update the plugin's local path and checksum.
+	pluginConfig["localPath"] = localPath
+	pluginConfig["checksum"] = pluginFileSum
+
+	// Add the plugin config to the list of plugin configs.
+	added := false
+	for idx, plugin := range pluginsList {
+		if pluginInstance, ok := plugin.(map[string]interface{}); ok {
+			if pluginInstance["name"] == pluginName {
+				pluginsList[idx] = pluginConfig
+				added = true
+				break
+			}
+		}
+	}
+	if !added {
+		pluginsList = append(pluginsList, pluginConfig)
+	}
+
+	// Merge the result back into the config map.
+	localPluginsConfig["plugins"] = pluginsList
+
+	// Marshal the map into YAML.
+	updatedPlugins, err := yamlv3.Marshal(localPluginsConfig)
+	if err != nil {
+		cmd.Println("There was an error marshalling the plugins configuration: ", err)
+		return
+	}
+
+	// Write the YAML to the plugins config file.
+	if err = os.WriteFile(pluginConfigFile, updatedPlugins, FilePermissions); err != nil {
+		cmd.Println("There was an error writing the plugins configuration file: ", err)
+		return
+	}
+
+	// Delete the downloaded and extracted files, except the plugin binary,
+	// if the --cleanup flag is set.
+	if cleanup {
+		deleteFiles(toBeDeleted)
+	}
+
+	// TODO: Add a rollback mechanism.
+	cmd.Println("Plugin installed successfully")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -442,7 +442,7 @@ func downloadFile(
 func deleteFiles(toBeDeleted []string) {
 	for _, filename := range toBeDeleted {
 		if err := os.Remove(filename); err != nil {
-			fmt.Println("There was an error deleting the file: ", err)
+			fmt.Println("There was an error deleting the file: ", err) //nolint:forbidigo
 			return
 		}
 	}
@@ -484,13 +484,13 @@ func getFileExtension() Extension {
 func installPlugin(cmd *cobra.Command, pluginURL string) {
 	var (
 		// This is a list of files that will be deleted after the plugin is installed.
-		toBeDeleted []string = []string{}
+		toBeDeleted = []string{}
 
 		// Source of the plugin: file or GitHub.
-		source Source = detectSource(pluginURL)
+		source = detectSource(pluginURL)
 
 		// The extension of the archive based on the OS: .zip or .tar.gz.
-		archiveExt Extension = getFileExtension()
+		archiveExt = getFileExtension()
 
 		releaseID         int64
 		downloadURL       string
@@ -666,6 +666,7 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 			}
 			return
 		}
+	case SourceUnknown:
 	default:
 		cmd.Println("Invalid URL or file path")
 	}
@@ -676,16 +677,14 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 	// Create a new "gatewayd_plugins.yaml" file if it doesn't exist.
 	if _, err := os.Stat(pluginConfigFile); os.IsNotExist(err) {
 		generateConfig(cmd, Plugins, pluginConfigFile, false)
-	} else {
+	} else if !backupConfig && !noPrompt {
 		// If the config file exists, we should prompt the user to backup
 		// the plugins configuration file.
-		if !backupConfig && !noPrompt {
-			cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
-			var backupOption string
-			_, err := fmt.Scanln(&backupOption)
-			if err == nil && (backupOption == "y" || backupOption == "Y") {
-				backupConfig = true
-			}
+		cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
+		var backupOption string
+		_, err := fmt.Scanln(&backupOption)
+		if err == nil && (backupOption == "y" || backupOption == "Y") {
+			backupConfig = true
 		}
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -684,7 +684,9 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 		cmd.Print("Do you want to backup the plugins configuration file? [Y/n] ")
 		var backupOption string
 		_, err := fmt.Scanln(&backupOption)
-		if err == nil && (backupOption == "y" || backupOption == "Y") {
+		if err == nil && strings.ToLower(backupOption) == "n" {
+			backupConfig = false
+		} else {
 			backupConfig = true
 		}
 	}
@@ -720,7 +722,7 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 
 				var updateOption string
 				_, err := fmt.Scanln(&updateOption)
-				if err == nil && (updateOption == "y" || updateOption == "Y") {
+				if err != nil && strings.ToLower(updateOption) == "y" {
 					break
 				}
 			}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -861,10 +861,12 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 		return
 	}
 
-	// Write the YAML to the plugins config file.
-	if err = os.WriteFile(pluginConfigFile, updatedPlugins, FilePermissions); err != nil {
-		cmd.Println("There was an error writing the plugins configuration file: ", err)
-		return
+	// Write the YAML to the plugins config file if the --overwrite-config flag is set.
+	if overwriteConfig {
+		if err = os.WriteFile(pluginConfigFile, updatedPlugins, FilePermissions); err != nil {
+			cmd.Println("There was an error writing the plugins configuration file: ", err)
+			return
+		}
 	}
 
 	// Delete the downloaded and extracted files, except the plugin binary,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -294,6 +294,7 @@ func extractTarGz(filename, dest string) ([]string, error) {
 	if err != nil {
 		return nil, gerr.ErrExtractFailed.Wrap(err)
 	}
+	defer uncompressedStream.Close()
 
 	// Create the output directory if it doesn't exist.
 	if err := os.MkdirAll(dest, FolderPermissions); err != nil {

--- a/config/types.go
+++ b/config/types.go
@@ -12,6 +12,7 @@ type Plugin struct {
 	Args      []string `json:"args"`
 	Env       []string `json:"env" jsonschema:"required"`
 	Checksum  string   `json:"checksum" jsonschema:"required"`
+	URL       string   `json:"url"`
 }
 
 type PluginConfig struct {

--- a/gatewayd_plugins.yaml
+++ b/gatewayd_plugins.yaml
@@ -79,6 +79,7 @@ startTimeout: 1m
 plugins:
   - name: gatewayd-plugin-cache
     enabled: True
+    url: github.com/gatewayd/gatewayd-plugin-cache@latest
     localPath: ../gatewayd-plugin-cache/gatewayd-plugin-cache
     args: ["--log-level", "debug"]
     env:

--- a/gatewayd_plugins.yaml
+++ b/gatewayd_plugins.yaml
@@ -79,7 +79,7 @@ startTimeout: 1m
 plugins:
   - name: gatewayd-plugin-cache
     enabled: True
-    url: github.com/gatewayd/gatewayd-plugin-cache@latest
+    url: github.com/gatewayd-io/gatewayd-plugin-cache@latest
     localPath: ../gatewayd-plugin-cache/gatewayd-plugin-cache
     args: ["--log-level", "debug"]
     env:

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/prometheus/common v0.46.0
 	github.com/rs/zerolog v1.31.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
@@ -338,6 +340,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
+github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/plugin/plugin_registry.go
+++ b/plugin/plugin_registry.go
@@ -398,6 +398,7 @@ func (reg *Registry) LoadPlugins(
 		pluginCtx, span := otel.Tracer("").Start(ctx, "Load plugin")
 		span.SetAttributes(attribute.Int("priority", priority))
 		span.SetAttributes(attribute.String("name", pCfg.Name))
+		span.SetAttributes(attribute.String("url", pCfg.URL))
 		span.SetAttributes(attribute.Bool("enabled", pCfg.Enabled))
 		span.SetAttributes(attribute.String("checksum", pCfg.Checksum))
 		span.SetAttributes(attribute.String("local_path", pCfg.LocalPath))


### PR DESCRIPTION
# Ticket(s)

- #402 

## Description

This PR introduces a notable enhancement for creating stateless pods in Kubernetes (k8s) by automating the plugin installation process. At present, installing plugins in GatewayD requires manual intervention, where each plugin is installed using the GatewayD CLI with a GitHub URL or a local file path of a plugin archive. This method requires executing `gatewayd plugin install` individually for each plugin, which is inefficient (in general and also) for Kubernetes environments. A more automated approach is needed for installing and configuring plugins in k8s. Currently, the only feasible method for plugin installation involves using a volume to store the plugins and a script to execute the plugin installation commands. This approach ensures that restarting a pod does not erase the plugin configurations and binaries.

To address these challenges, this PR automates the plugin installation process by introducing a `url` parameter in the `gatewayd_plugins.yaml` configuration file. Consequently, executing `gatewayd plugin install` without specifying CLI arguments (such as a GitHub URL or file path) will trigger the following automated steps:

1. Parse the `gatewayd_plugins.yaml` file to extract all the plugin URLs.
2. Download and unpack the plugin archives from the specified URLs.
3. Install the plugins, with the installation details reflected in the updated `gatewayd_plugins.yaml` file. 

It also adds support for the `--overwrite-config` flag that can be used to disable overwriting the plugins config file after the plugins are installed.

### Note

Since the automated plugin installation relies on the `gatewayd_plugins.yaml` file to be up to date with all the configuration, local paths and checksums for the latest plugins, and overwriting the plugins config file might be disabled by the user (for example, since they use configmaps), one should make sure to use the correct local paths and checksums.

## Related PRs

N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
