### PR TITLE
test: Make plugin tests OS independent

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -177,6 +177,7 @@ func TestGetProxies(t *testing.T) {
 		Address: config.DefaultAddress,
 	}
 	client := network.NewClient(context.TODO(), clientConfig, zerolog.Logger{}, nil)
+	require.NotNil(t, client)
 	newPool := pool.NewPool(context.TODO(), 1)
 	assert.Nil(t, newPool.Put(client.ID, client))
 

--- a/cmd/cmd_helpers_test.go
+++ b/cmd/cmd_helpers_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +26,14 @@ func executeCommandC(root *cobra.Command, args ...string) (string, error) {
 // mustPullPlugin pulls the gatewayd-plugin-cache plugin and returns the path to the archive.
 func mustPullPlugin() (string, error) {
 	pluginURL := "github.com/gatewayd-io/gatewayd-plugin-cache@v0.2.10"
-	fileName := "./gatewayd-plugin-cache-linux-amd64-v0.2.10.tar.gz"
+
+	fileName := fmt.Sprintf(
+		"./gatewayd-plugin-cache-%s-%s-%s%s",
+		runtime.GOOS,
+		runtime.GOARCH,
+		"v0.2.10",
+		getFileExtension(),
+	)
 
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		_, err := executeCommandC(rootCmd, "plugin", "install", "--pull-only", pluginURL)

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 		rootCmd, "plugin", "install",
 		"-p", pluginTestConfigFile, "--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Contains(t, output, "/gatewayd-plugin-cache-linux-amd64-")
+	assert.Contains(t, output, fmt.Sprintf("/gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
 	assert.Contains(t, output, "/checksums.txt")
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")


### PR DESCRIPTION
## Description
The tests were not passing on MacOS because the expected plugin file name was hardcoded to include `linux-amd`, while plugin command will download the OS-specific file. This PR fixes this issue.

Also, in `api_test.go` client can be `nil` (for example if `psql` is not running), added a `require.NotNil` to fail gracefully instead of panicking.
## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
