### PR TITLE
tests: use buffer instead of capturer to test logger output

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -137,6 +137,7 @@ jobs:
           plugins:
             - name: plugin-template-go
               enabled: True
+              url: github.com/gatewayd-io/plugin-template-go
               localPath: ./ptg
               args: ["--log-level", "debug"]
               env:

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zenizh/go-capturer"
 )
 
 var (
@@ -39,10 +38,9 @@ func Test_runCmd(t *testing.T) {
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		// Test run command.
-		output := capturer.CaptureOutput(func() {
-			_, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
-			require.NoError(t, err, "run command should not have returned an error")
-		})
+		output, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
+		require.NoError(t, err, "run command should not have returned an error")
+
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
@@ -93,10 +91,8 @@ func Test_runCmdWithTLS(t *testing.T) {
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		// Test run command.
-		output := capturer.CaptureOutput(func() {
-			_, err := executeCommandC(rootCmd, "run", "-c", globalTLSTestConfigFile, "-p", pluginTestConfigFile)
-			require.NoError(t, err, "run command should not have returned an error")
-		})
+		output, err := executeCommandC(rootCmd, "run", "-c", globalTLSTestConfigFile, "-p", pluginTestConfigFile)
+		require.NoError(t, err, "run command should not have returned an error")
 
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
@@ -149,11 +145,10 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		// Test run command.
-		output := capturer.CaptureOutput(func() {
-			_, err := executeCommandC(
-				rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
-			require.NoError(t, err, "run command should not have returned an error")
-		})
+		output, err := executeCommandC(
+			rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
+		require.NoError(t, err, "run command should not have returned an error")
+
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.
@@ -232,10 +227,9 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		// Test run command.
-		output := capturer.CaptureOutput(func() {
-			_, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
-			require.NoError(t, err, "run command should not have returned an error")
-		})
+		output, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
+		require.NoError(t, err, "run command should not have returned an error")
+
 		// Print the output for debugging purposes.
 		runCmd.Print(output)
 		// Check if GatewayD started and stopped correctly.

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -36,6 +36,9 @@ type LoggerConfig struct {
 	Compress   bool
 	LocalTime  bool
 
+	// the output of config.Console log will be written to this writer, if it is nil os.Stdout will be used.
+	ConsoleOut io.Writer
+
 	// group name
 	Name string
 }
@@ -45,8 +48,13 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 	_, span := otel.Tracer(config.TracerName).Start(ctx, "Create new logger")
 
 	// Create a new logger.
+	var consoleOut io.Writer = os.Stdout
+	if cfg.ConsoleOut != nil {
+		consoleOut = cfg.ConsoleOut
+	}
+
 	consoleWriter := zerolog.ConsoleWriter{
-		Out:        os.Stdout,
+		Out:        consoleOut,
 		TimeFormat: cfg.ConsoleTimeFormat,
 		NoColor:    cfg.NoColor,
 	}
@@ -92,7 +100,6 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 			outputs = append(outputs, consoleWriter)
 		}
 	}
-
 	zerolog.SetGlobalLevel(cfg.Level)
 	zerolog.TimeFieldFormat = cfg.TimeFormat
 

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"testing"
@@ -104,6 +105,27 @@ func TestNewLogger_Stderr(t *testing.T) {
 	assert.Contains(t, stderr, `"level":"error"`)
 	assert.Contains(t, stderr, "This is an error")
 	assert.Contains(t, stderr, `"key":"value"`)
+}
+
+// TestNewLogger_CustomOutput tests the creation of a new logger with bytes.Buffer as custom output.
+func TestNewLogger_ConsoleOut(t *testing.T) {
+	out := &bytes.Buffer{}
+	logger := NewLogger(
+		context.Background(),
+		LoggerConfig{
+			Output:     []config.LogOutput{config.Console},
+			ConsoleOut: out,
+			Level:      zerolog.DebugLevel,
+			TimeFormat: zerolog.TimeFormatUnix,
+			NoColor:    true,
+		},
+	)
+	assert.NotNil(t, logger)
+
+	logger.Error().Str("key", "value").Msg("This is an error")
+	got := out.String()
+	assert.Contains(t, got, `ERR This is an error`)
+	assert.Contains(t, got, `key=value`)
 }
 
 // TestNewLogger_MultipleOutputs tests the creation of a new logger with multiple outputs.


### PR DESCRIPTION
# Ticket(s)
addresses https://github.com/gatewayd-io/gatewayd/issues/457

## Description
Adds the option to write logger console output to a custom `io.Writer`. This helps with the tests that directly test the logger. Also, enables the use of cobra `cmd.Print` instead of plain `os.Stdout` for the logger to help with tests using `executeC` and `root.SetOut`.

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
