### PR TITLE
Implement ConsoleOut in Windows logger

### DIFF
--- a/logging/logger_windows.go
+++ b/logging/logger_windows.go
@@ -35,6 +35,9 @@ type LoggerConfig struct {
 	Compress   bool
 	LocalTime  bool
 
+	// the output of config.Console log will be written to this writer, if it is nil os.Stdout will be used.
+	ConsoleOut io.Writer
+
 	// group name
 	Name string
 }
@@ -44,8 +47,13 @@ func NewLogger(ctx context.Context, cfg LoggerConfig) zerolog.Logger {
 	_, span := otel.Tracer(config.TracerName).Start(ctx, "Create new logger")
 
 	// Create a new logger.
+	var consoleOut io.Writer = os.Stdout
+	if cfg.ConsoleOut != nil {
+		consoleOut = cfg.ConsoleOut
+	}
+
 	consoleWriter := zerolog.ConsoleWriter{
-		Out:        os.Stdout,
+		Out:        consoleOut,
 		TimeFormat: cfg.ConsoleTimeFormat,
 		NoColor:    cfg.NoColor,
 	}


### PR DESCRIPTION
# Ticket(s)
- #457 

## Description
The Windows logger uses a different file that omits syslog, hence is usually overlooked. This fixes the `ConsoleOut` feature implemented by @Hamsajj in #457.

## Related PRs
- #476  

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
