### PR TITLE
Make sure to stop the plugin registry gracefully if the database is not available

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -713,7 +713,23 @@ var runCmd = &cobra.Command{
 					}
 				} else {
 					logger.Error().Msg("Failed to create client, please check the configuration")
-					os.Exit(gerr.FailedToCreateClient)
+					go func() {
+						// Wait for the stop signal to exit gracefully.
+						// This prevents the program from waiting indefinitely
+						// after the StopGracefully function is called.
+						<-stopChan
+						os.Exit(gerr.FailedToCreateClient)
+					}()
+					StopGracefully(
+						runCtx,
+						nil,
+						metricsMerger,
+						metricsServer,
+						pluginRegistry,
+						logger,
+						servers,
+						stopChan,
+					)
 				}
 			}
 


### PR DESCRIPTION
# Ticket(s)
Closes #482 

## Description
This PR ensures clean exit when the database is not available and creating a client connection fails after retries.

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
