### PR TITLE
Fix plugin install errors

### DIFF
--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -462,7 +462,7 @@ func downloadFile(
 
 	// Create the output file in the current directory and write the downloaded content.
 	var filePath string
-	if outputDir == "" {
+	if outputDir == "" || !filepath.IsAbs(outputDir) {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return "", gerr.ErrDownloadFailed.Wrap(err)
@@ -470,18 +470,6 @@ func downloadFile(
 		filePath = path.Join([]string{cwd, filename}...)
 	} else {
 		filePath = path.Join([]string{outputDir, filename}...)
-	}
-
-	absPath, err := filepath.Abs(filePath)
-	if err != nil {
-		return "", gerr.ErrDownloadFailed.Wrap(err)
-	}
-
-	// If the file exists and is not empty, return the file path.
-	// NOTE: This is to prevent re-downloading the same file.
-	// The user can delete the file and re-run the command to download the file again.
-	if fileInfo, err := os.Stat(absPath); err == nil && fileInfo.Size() > 0 {
-		return absPath, nil
 	}
 
 	output, err := os.Create(filePath)
@@ -648,13 +636,6 @@ func installPlugin(cmd *cobra.Command, pluginURL string) {
 		// Create the output directory if it doesn't exist.
 		if err := os.MkdirAll(pluginOutputDir, FolderPermissions); err != nil {
 			cmd.Println("There was an error creating the output directory: ", err)
-			return
-		}
-
-		// The output directory should be an absolute path.
-		pluginOutputDir, err = filepath.Abs(pluginOutputDir)
-		if err != nil {
-			cmd.Println("There was an error getting the absolute path: ", err)
 			return
 		}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -48,6 +48,7 @@ const (
 	ErrCodeAsyncAction
 	ErrCodeEvalError
 	ErrCodeMsgEncodeError
+	ErrCodePathSlipError
 )
 
 var (


### PR DESCRIPTION
# Ticket(s)
Related to #376 

## Description
This PR introduces a new flag to disable Tar and Zip Slip verification to allow isolated environment like Docker extract and install plugins into absolute paths.

## Related PRs
- https://github.com/gatewayd-io/docs/pull/47

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
