### PR TITLE
Revamp docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ libtensorflow*
 # Test generated files
 cmd/test_*.yaml.bak
 cmd/test_*.yaml
+
+# docker-compose
+gatewayd-files/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,20 @@
 version: "3.8"
 services:
+  install_plugins:
+    # This intermediate service is used to install the plugins
+    # before starting the GatewayD service.
+    image: alpine:3.18
+    command: ["/bin/sh", "/setup.sh"]
+    volumes:
+      - ./setup.sh:/setup.sh:ro
+      # Use the variable defined above to mount the GatewayD files.
+      - ./gatewayd-files:/gatewayd-files:rw
+    environment:
+      - GATEWAYD_FILES=/gatewayd-files
+      # If you want to install a specific version of GatewayD, you can set the
+      # GATEWAYD_VERSION environment variable to the desired version. Otherwise,
+      # the latest version will be installed.
+      # - GATEWAYD_VERSION=v0.9.2
   postgres:
     image: postgres:latest
     environment:
@@ -10,18 +25,39 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:latest
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   gatewayd:
     image: gatewaydio/gatewayd:latest
-    command: ["run"]
+    command: [
+      "run",
+      "--config", "/gatewayd-files/gatewayd.yaml",
+      "--plugin-config", "/gatewayd-files/gatewayd_plugins.yaml"
+    ]
     environment:
       # For more information about the environment variables, see:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables
       - GATEWAYD_CLIENTS_DEFAULT_ADDRESS=postgres:5432
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
-      - "15432:15432"
+      - "15432:15432" # GatewayD server for PostgreSQL clients to connect to
+      - "9090:9090"   # Prometheus metrics:
+                      #   http://localhost:9090/metrics
+      - "18080:18080" # GatewayD HTTP gateway:
+                      #   http://localhost:18080/swagger-ui/ for the API documentation
+                      #   http://localhost:18080/healthz for the health check
+      - "19090:19090" # GatewayD gRPC API with reflection enabled:
+                      #   You can use grpcurl or grpc-client-cli to interact with it
+    volumes:
+      - ./gatewayd-files:/gatewayd-files:ro
     links:
       - postgres
+      - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://gatewayd:18080/healthz"]
       interval: 5s
@@ -30,3 +66,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+      install_plugins:
+        condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,11 @@ services:
       - "15432:15432"
     links:
       - postgres
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://gatewayd:18080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     depends_on:
       postgres:
         condition: service_healthy

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script is used to install the required packages and download
+# the latest version of GatewayD from GitHub and install the plugins.
+
+# Get the latest released version of GatewayD from GitHub
+[ -z ${GATEWAYD_VERSION} ] && export GATEWAYD_VERSION=$(git ls-remote --tags --sort=v:refname "https://github.com/gatewayd-io/gatewayd" | cut -d/ -f3- | tail -n1)
+
+# Set the environment variables if they are not set
+[ -z ${GATEWAYD_FILES} ] && export GATEWAYD_FILES=/gatewayd-files
+
+# Install the required packages
+apk add --no-cache curl git
+
+# Create the directory to store the gatewayd files
+[ -d ${GATEWAYD_FILES} ] || mkdir ${GATEWAYD_FILES}
+
+cd ${GATEWAYD_FILES}
+
+# Download the GatewayD archive if it doesn't exist
+[ -f ${GATEWAYD_FILES}/gatewayd-linux-amd64-${GATEWAYD_VERSION}.tar.gz ] || curl -L https://github.com/gatewayd-io/gatewayd/releases/download/${GATEWAYD_VERSION}/gatewayd-linux-amd64-${GATEWAYD_VERSION}.tar.gz | tar zxvf -
+chmod +x gatewayd
+
+# Install the GatewayD plugins
+${GATEWAYD_FILES}/gatewayd plugin install --skip-path-slip-verification --output-dir ${GATEWAYD_FILES} --plugin-config ${GATEWAYD_FILES}/gatewayd_plugins.yaml --cleanup=false --update --overwrite-config
+
+# Replace the default Redis URL
+sed -i 's/redis:\/\/localhost:6379/redis:\/\/redis:6379/' ${GATEWAYD_FILES}/gatewayd_plugins.yaml


### PR DESCRIPTION
# Ticket(s)
Closes #376 

## Description
In this PR I revamped the docker compose file by introducing a new intermediate service, which is an alpine image that runs the `setup.sh` script, which subsequently downloads GatewayD and plugins and installs them. The `redis` image is also added to make the cache plugin work as expected. GatewayD ports are exposed to make them available to the host machine.

## Related PRs
N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
