### PR TITLE
Add timeout for running actions

### DIFF
--- a/act/act_helpers_test.go
+++ b/act/act_helpers_test.go
@@ -1,0 +1,51 @@
+package act
+
+import (
+	"time"
+
+	sdkAct "github.com/gatewayd-io/gatewayd-plugin-sdk/act"
+)
+
+func createWaitActEntities(async bool) (
+	string,
+	map[string]*sdkAct.Action,
+	map[string]*sdkAct.Signal,
+	map[string]*sdkAct.Policy,
+) {
+	name := "waitSync"
+	if async {
+		name = "waitAsync"
+	}
+	actions := map[string]*sdkAct.Action{
+		name: {
+			Name:     name,
+			Metadata: nil,
+			Sync:     !async,
+			Terminal: false,
+			Run: func(_ map[string]any, _ ...sdkAct.Parameter) (any, error) {
+				time.Sleep(1 * time.Second)
+				return true, nil
+			},
+		},
+	}
+	signals := map[string]*sdkAct.Signal{
+		name: {
+			Name: name,
+			Metadata: map[string]any{
+				"log":     true,
+				"level":   "info",
+				"message": "test",
+				"async":   async,
+			},
+		},
+	}
+	policy := map[string]*sdkAct.Policy{
+		name: sdkAct.MustNewPolicy(
+			name,
+			`true`,
+			map[string]any{"log": "enabled"},
+		),
+	}
+
+	return name, actions, signals, policy
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -108,7 +108,7 @@ func TestGetPluginConfig(t *testing.T) {
 func TestGetPlugins(t *testing.T) {
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, zerolog.Logger{})
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, zerolog.Logger{})
 	pluginRegistry := plugin.NewRegistry(
 		context.TODO(),
 		actRegistry,
@@ -137,7 +137,7 @@ func TestGetPlugins(t *testing.T) {
 func TestGetPluginsWithEmptyPluginRegistry(t *testing.T) {
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, zerolog.Logger{})
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, zerolog.Logger{})
 	pluginRegistry := plugin.NewRegistry(
 		context.TODO(),
 		actRegistry,
@@ -229,6 +229,7 @@ func TestGetServers(t *testing.T) {
 	}
 	client := network.NewClient(context.TODO(), clientConfig, zerolog.Logger{}, nil)
 	newPool := pool.NewPool(context.TODO(), 1)
+	require.NotNil(t, newPool)
 	assert.Nil(t, newPool.Put(client.ID, client))
 
 	proxy := network.NewProxy(
@@ -246,7 +247,7 @@ func TestGetServers(t *testing.T) {
 
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, zerolog.Logger{})
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, zerolog.Logger{})
 
 	pluginRegistry := plugin.NewRegistry(
 		context.TODO(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -285,7 +285,7 @@ var runCmd = &cobra.Command{
 		// Create a new act registry given the built-in signals, policies, and actions.
 		actRegistry = act.NewActRegistry(
 			act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-			conf.Plugin.DefaultPolicy, conf.Plugin.PolicyTimeout, logger,
+			conf.Plugin.DefaultPolicy, conf.Plugin.PolicyTimeout, conf.Plugin.ActionTimeout, logger,
 		)
 
 		if actRegistry == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -214,6 +214,7 @@ func (c *Config) LoadDefaults(ctx context.Context) {
 		StartTimeout:        DefaultPluginStartTimeout,
 		DefaultPolicy:       DefaultPolicy,
 		PolicyTimeout:       DefaultPolicyTimeout,
+		ActionTimeout:       DefaultActionTimeout,
 		Policies:            []Policy{},
 	}
 

--- a/config/constants.go
+++ b/config/constants.go
@@ -125,4 +125,5 @@ const (
 	// Act.
 	DefaultPolicy        = "passthrough"
 	DefaultPolicyTimeout = 30 * time.Second
+	DefaultActionTimeout = 30 * time.Second
 )

--- a/config/types.go
+++ b/config/types.go
@@ -32,6 +32,7 @@ type PluginConfig struct {
 	Plugins             []Plugin      `json:"plugins"`
 	DefaultPolicy       string        `json:"defaultPolicy" jsonschema:"enum=passthrough,enum=terminate"` // TODO: Add more policies.
 	PolicyTimeout       time.Duration `json:"policyTimeout" jsonschema:"oneof_type=string;integer"`
+	ActionTimeout       time.Duration `json:"actionTimeout" jsonschema:"oneof_type=string;integer"`
 	Policies            []Policy      `json:"policies"`
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -148,6 +148,8 @@ var (
 		ErrCodeRunError, "error running action", nil)
 	ErrAsyncAction = NewGatewayDError(
 		ErrCodeAsyncAction, "async action", nil)
+	ErrRunningActionTimeout = NewGatewayDError(
+		ErrCodeRunError, "timeout running action", nil)
 	ErrActionNotMatched = NewGatewayDError(
 		ErrCodeKeyNotFound, "no matching action", nil)
 	ErrPolicyNotMatched = NewGatewayDError(

--- a/network/proxy_test.go
+++ b/network/proxy_test.go
@@ -47,7 +47,7 @@ func TestNewProxy(t *testing.T) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	proxy := NewProxy(
@@ -93,7 +93,7 @@ func BenchmarkNewProxy(b *testing.B) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	for i := 0; i < b.N; i++ {
@@ -142,7 +142,7 @@ func BenchmarkProxyConnectDisconnect(b *testing.B) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	proxy := NewProxy(
@@ -197,7 +197,7 @@ func BenchmarkProxyPassThrough(b *testing.B) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	proxy := NewProxy(
@@ -257,7 +257,7 @@ func BenchmarkProxyIsHealthyAndIsExhausted(b *testing.B) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	proxy := NewProxy(
@@ -315,7 +315,7 @@ func BenchmarkProxyAvailableAndBusyConnections(b *testing.B) {
 	// Create a new act registry
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 
 	// Create a proxy with a fixed buffer newPool
 	proxy := NewProxy(

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -41,7 +41,7 @@ func TestRunServer(t *testing.T) {
 
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 	pluginRegistry := plugin.NewRegistry(
 		context.Background(),
 		actRegistry,

--- a/plugin/plugin_registry_test.go
+++ b/plugin/plugin_registry_test.go
@@ -28,7 +28,7 @@ func NewPluginRegistry(t *testing.T) *Registry {
 	logger := logging.NewLogger(context.Background(), cfg)
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 	reg := NewRegistry(
 		context.Background(),
 		actRegistry,
@@ -130,7 +130,7 @@ func BenchmarkHookRun(b *testing.B) {
 	logger := logging.NewLogger(context.Background(), cfg)
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger)
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger)
 	reg := NewRegistry(
 		context.Background(),
 		actRegistry,

--- a/plugin/utils_test.go
+++ b/plugin/utils_test.go
@@ -92,7 +92,7 @@ func Test_applyPolicies(t *testing.T) {
 	logger := zerolog.Logger{}
 	actRegistry := act.NewActRegistry(
 		act.BuiltinSignals(), act.BuiltinPolicies(), act.BuiltinActions(),
-		config.DefaultPolicy, config.DefaultPolicyTimeout, logger,
+		config.DefaultPolicy, config.DefaultPolicyTimeout, config.DefaultActionTimeout, logger,
 	)
 
 	output := applyPolicies(


### PR DESCRIPTION
# Ticket(s)

## Description
(This PR is in draft because it depends on https://github.com/gatewayd-io/gatewayd-plugin-sdk/pull/26)
This PR will close #463 by adding timeout for running action.

Timeout will be defined by two different configs. One on the act system level, which will act as a default timeout and is added in this PR. the other config is on Action level, which allows each action to have a different timeout and will override the default one.
That config is added in https://github.com/gatewayd-io/gatewayd-plugin-sdk/pull/26

If both of these values are zero, actions will run without any timeout.
## Related PRs
https://github.com/gatewayd-io/gatewayd-plugin-sdk/pull/26
## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added docstring(s) to my code.
- [x] I have made corresponding changes to the documentation (docs).
- [x] I have updated docs using `make gen-docs` command.
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
