### PR TITLE
Fix HTTP Server errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -100,7 +100,7 @@ func (a *API) GetGlobalConfig(_ context.Context, group *v1.Group) (*structpb.Str
 
 // GetPluginConfig returns the plugin configuration of the GatewayD.
 func (a *API) GetPluginConfig(context.Context, *emptypb.Empty) (*structpb.Struct, error) {
-	jsonData, err := json.Marshal(a.Config.PluginKoanf.All())
+	jsonData, err := json.Marshal(a.Config.Plugin)
 	if err != nil {
 		metrics.APIRequestsErrors.WithLabelValues(
 			"GET", "/v1/GatewayDPluginService/GetPluginConfig", codes.Internal.String(),

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -50,16 +50,12 @@ func (s *HTTPServer) Shutdown(ctx context.Context) {
 
 // CreateHTTPAPI creates a new HTTP API.
 func createHTTPAPI(options *Options) *http.Server {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	// Register gRPC server endpoint
 	// TODO: Make this configurable with TLS and Auth.
 	rmux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	err := v1.RegisterGatewayDAdminAPIServiceHandlerFromEndpoint(
-		ctx, rmux, options.GRPCAddress, opts)
+		context.Background(), rmux, options.GRPCAddress, opts)
 	if err != nil {
 		options.Logger.Err(err).Msg("failed to start HTTP API")
 	}


### PR DESCRIPTION
# Ticket(s)
- #439 

## Description
This PR fixes two bugs:
1. The gRPC client in the HTTP server used to use a context with cancel, and it was refactored to add graceful stop functionality, hence the function now returns an `http.Server` instead. This causes the defer to be called to cancel the context, hence a closed gRPC client will be received by the gateway, which produced HTTP 499 with the message: `grpc: the client connection is closing`.
2. The previous code was using koanf, which was causing marshaling issues. Now the already unmarshaled struct is used.

## Related PRs
- #490 

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
