### PR TITLE
feat: use golang-queue to run async actions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,6 +70,7 @@ linters-settings:
           - "gopkg.in/natefinch/lumberjack.v2"
           - "github.com/expr-lang/expr"
           - "github.com/jackc/pgx/v5/pgproto3"
+          - "github.com/golang-queue/queue"
       test:
         files:
           - $test
@@ -88,6 +89,7 @@ linters-settings:
           - "github.com/knadh/koanf"
           - "github.com/spf13/cast"
           - "github.com/jackc/pgx/v5/pgproto3"
+          - "github.com/golang-queue/queue"
   tagalign:
     align: false
     sort: false

--- a/act/worker.go
+++ b/act/worker.go
@@ -1,0 +1,115 @@
+package act
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	sdkAct "github.com/gatewayd-io/gatewayd-plugin-sdk/act"
+	gerr "github.com/gatewayd-io/gatewayd/errors"
+	"github.com/golang-queue/queue/core"
+	"github.com/rs/zerolog"
+)
+
+type IWorker interface {
+	RunFunc() func(ctx context.Context, m core.QueuedMessage) error
+}
+
+// Worker keeps track of all policies and actions.
+type Worker struct {
+	Logger               zerolog.Logger
+	DefaultActionTimeout time.Duration
+
+	Actions map[string]*sdkAct.Action
+}
+
+var _ IWorker = (*Worker)(nil)
+
+// NewActWorker creates a new act worker.
+func NewActWorker(
+	worker Worker,
+) *Worker {
+	if worker.Actions == nil {
+		worker.Logger.Warn().Msg("Builtin actions are nil")
+		return nil
+	}
+
+	for _, action := range worker.Actions {
+		if action == nil {
+			worker.Logger.Warn().Msg("Action is nil, not adding")
+			return nil
+		}
+		worker.Logger.Debug().Str("name", action.Name).Msg("Registered builtin action")
+	}
+
+	return &Worker{
+		Logger:               worker.Logger,
+		Actions:              worker.Actions,
+		DefaultActionTimeout: worker.DefaultActionTimeout,
+	}
+}
+
+func (w *Worker) RunFunc() func(ctx context.Context, m core.QueuedMessage) error {
+	return func(ctx context.Context, m core.QueuedMessage) error {
+		actionMessage, ok := m.(*asyncActionMessage)
+		if !ok {
+			if err := json.Unmarshal(m.Bytes(), &actionMessage); err != nil {
+				return fmt.Errorf("failed to unmarshal action message message: %w", err)
+			}
+		}
+		res, err := w.runAction(ctx, actionMessage.Output, actionMessage.Params...)
+		if err == nil {
+			w.Logger.Debug().Interface("result", res).Msg("Action ran successfully")
+		}
+		return err
+	}
+}
+
+// Run runs the function associated with the output.MatchedPolicy and
+// returns its result.
+func (w *Worker) runAction(
+	ctx context.Context,
+	output *sdkAct.Output, params ...sdkAct.Parameter,
+) (any, *gerr.GatewayDError) {
+	// In certain cases, the output may be nil, for example, if the policy
+	// evaluation fails. In this case, the run is aborted.
+	if output == nil {
+		// This should never happen, since the output is always set by the registry
+		// to be the default policy if no signals are provided.
+		w.Logger.Debug().Msg("Output is nil, run aborted")
+		return nil, gerr.ErrNilPointer
+	}
+
+	action, ok := w.Actions[output.MatchedPolicy]
+	if !ok {
+		w.Logger.Warn().Str("matchedPolicy", output.MatchedPolicy).Msg(
+			"Action does not exist, run aborted")
+		return nil, gerr.ErrActionNotExist
+	}
+
+	// Prepend the logger to the parameters.
+	params = append([]sdkAct.Parameter{WithLogger(w.Logger)}, params...)
+
+	timeout := w.DefaultActionTimeout
+	if action.Timeout > 0 {
+		timeout = time.Duration(action.Timeout) * time.Second
+	}
+
+	// If the action is asynchronous, run it and return the result immediately.
+	if action.Sync {
+		w.Logger.Warn().Str("action", action.Name).Msg("Action is synchronous, run aborted")
+		return nil, gerr.ErrSyncActionInQueue
+	}
+
+	var ctxWithTimeout context.Context
+	var cancel context.CancelFunc
+	// if timeout is zero, then the context should not have timeout
+	if timeout > 0 {
+		ctxWithTimeout, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctxWithTimeout, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+	return runActionWithTimeout(ctxWithTimeout, action, output, params, w.Logger)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/network"
 	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/pool"
+	"github.com/golang-queue/queue"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,6 +129,7 @@ func TestGetPlugins(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               zerolog.Logger{},
+			ActionQueue:          &queue.Queue{},
 		})
 	pluginRegistry := plugin.NewRegistry(
 		context.TODO(),
@@ -182,6 +184,7 @@ func TestGetPluginsWithEmptyPluginRegistry(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               zerolog.Logger{},
+			ActionQueue:          &queue.Queue{},
 		})
 	pluginRegistry := plugin.NewRegistry(
 		context.TODO(),
@@ -303,6 +306,7 @@ func TestGetServers(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               zerolog.Logger{},
+			ActionQueue:          &queue.Queue{},
 		})
 
 	pluginRegistry := plugin.NewRegistry(

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -49,6 +49,7 @@ const (
 	ErrCodeEvalError
 	ErrCodeMsgEncodeError
 	ErrCodeConfigParseError
+	ErrCodeAsyncQueueFailed
 )
 
 var (
@@ -178,6 +179,12 @@ var (
 		ErrCodeConfigParseError, "error parsing config", nil,
 	}
 
+	ErrAsyncQueueFailed = &GatewayDError{
+		ErrCodeAsyncQueueFailed, "async queue failed", nil,
+	}
+	ErrSyncActionInQueue = &GatewayDError{
+		ErrCodeRunError, "sync action in async queue", nil,
+	}
 	// Unwrapped errors.
 	ErrLoggerRequired = errors.New("terminate action requires a logger parameter")
 )
@@ -188,4 +195,5 @@ const (
 	FailedToStartServer       = 3
 	FailedToStartTracer       = 4
 	FailedToCreateActRegistry = 5
+	FailedToCreateWorkerQueue = 6
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.10
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-co-op/gocron v1.37.0
+	github.com/golang-queue/queue v0.2.0
 	github.com/google/go-github/v53 v53.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/hashicorp/go-hclog v1.6.3
@@ -61,6 +62,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/appleboy/com v0.1.7 h1:4lYTFNoMAAXGGIC8lDxVg/NY+1aXbYqfAWN05cZhd0M=
+github.com/appleboy/com v0.1.7/go.mod h1:JUK+oH0SXCLRH57pDMJx6VWVsm8CPdajalmRSWwamBE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -111,8 +113,12 @@ github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr6
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-queue/queue v0.2.0 h1:R0INU16rLCzYmc5h9wqHI/6owNxqcRVVMd5gyKVmnfU=
+github.com/golang-queue/queue v0.2.0/go.mod h1:5nEkJTzw9Boc8ZCylQlrJK5f/Vd8Uo58yAssRli5ckg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -215,6 +221,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/network/proxy_test.go
+++ b/network/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/logging"
 	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/pool"
+	"github.com/golang-queue/queue"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,6 +55,7 @@ func TestNewProxy(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool
@@ -110,6 +112,7 @@ func BenchmarkNewProxy(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool
@@ -169,6 +172,7 @@ func BenchmarkProxyConnectDisconnect(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool
@@ -235,6 +239,7 @@ func BenchmarkProxyPassThrough(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool
@@ -306,6 +311,7 @@ func BenchmarkProxyIsHealthyAndIsExhausted(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool
@@ -375,6 +381,7 @@ func BenchmarkProxyAvailableAndBusyConnectionsString(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	// Create a proxy with a fixed buffer newPool

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/logging"
 	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/pool"
+	"github.com/golang-queue/queue"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,7 @@ func TestRunServer(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 	pluginRegistry := plugin.NewRegistry(
 		context.Background(),

--- a/plugin/plugin_registry_test.go
+++ b/plugin/plugin_registry_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/act"
 	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/gatewayd-io/gatewayd/logging"
+	"github.com/golang-queue/queue"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -35,6 +36,7 @@ func NewPluginRegistry(t *testing.T) *Registry {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 	reg := NewRegistry(
 		context.Background(),
@@ -152,6 +154,7 @@ func BenchmarkHookRun(b *testing.B) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	reg := NewRegistry(

--- a/plugin/utils_test.go
+++ b/plugin/utils_test.go
@@ -7,6 +7,7 @@ import (
 	sdkAct "github.com/gatewayd-io/gatewayd-plugin-sdk/act"
 	"github.com/gatewayd-io/gatewayd/act"
 	"github.com/gatewayd-io/gatewayd/config"
+	"github.com/golang-queue/queue"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,7 @@ func Test_applyPolicies(t *testing.T) {
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
 			Logger:               logger,
+			ActionQueue:          &queue.Queue{},
 		})
 
 	output := applyPolicies(


### PR DESCRIPTION
# Ticket(s)
#464 
## Description
This PR aims to add queue for async action using [golang-queue project](https://github.com/golang-queue/queue).

This is in draft mode right now as it is not finished. I plan to do the following steps to call it done.
- [x] use an internal golang-queue to queue and run async actions (already done)
- [ ] make an `act.Queue` module as a wrapper around golang-queue which is configurable to either use internal or external (redis?) queue.
- [ ] create a new command that can be configured to listen to a external queue to run async actions (maybe part of #472 and not this one?)
