### PR TITLE
Fix setup issues

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,14 +51,18 @@ services:
       - GATEWAYD_CLIENTS_DEFAULT_ADDRESS=postgres:5432
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
-      - "15432:15432" # GatewayD server for PostgreSQL clients to connect to
-      - "9090:9090" # Prometheus metrics:
-        #   http://localhost:9090/metrics
-      - "18080:18080" # GatewayD HTTP gateway:
-        #   http://localhost:18080/swagger-ui/ for the API documentation
-        #   http://localhost:18080/healthz for the health check
-      - "19090:19090" # GatewayD gRPC API with reflection enabled:
-        #   You can use grpcurl or grpc-client-cli to interact with it
+      # GatewayD server for PostgreSQL clients to connect to
+      - "15432:15432"
+      # Prometheus metrics:
+      #   http://localhost:9090/metrics
+      - "9090:9090"
+      # GatewayD HTTP gateway:
+      #   http://localhost:18080/swagger-ui/ for the API documentation
+      #   http://localhost:18080/healthz for the health check
+      - "18080:18080"
+      # GatewayD gRPC API with reflection enabled:
+      #   You can use grpcurl or grpc-client-cli to interact with it
+      - "19090:19090"
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
     links:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,11 @@ services:
       # If you want to install a specific version of GatewayD, you can set the
       # GATEWAYD_VERSION environment variable to the desired version. Otherwise,
       # the latest version will be installed.
-      # - GATEWAYD_VERSION=v0.9.2
+      # - GATEWAYD_VERSION=v0.9.5
+      # The architecture of the GatewayD and plugins to install.
+      # Default: amd64
+      # Possible values: amd64 or arm64
+      - ARCH=amd64
   postgres:
     image: postgres:latest
     environment:
@@ -33,11 +37,14 @@ services:
       retries: 5
   gatewayd:
     image: gatewaydio/gatewayd:latest
-    command: [
-      "run",
-      "--config", "/gatewayd-files/gatewayd.yaml",
-      "--plugin-config", "/gatewayd-files/gatewayd_plugins.yaml"
-    ]
+    command:
+      [
+        "run",
+        "--config",
+        "/gatewayd-files/gatewayd.yaml",
+        "--plugin-config",
+        "/gatewayd-files/gatewayd_plugins.yaml",
+      ]
     environment:
       # For more information about the environment variables, see:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables
@@ -45,13 +52,13 @@ services:
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
       - "15432:15432" # GatewayD server for PostgreSQL clients to connect to
-      - "9090:9090"   # Prometheus metrics:
-                      #   http://localhost:9090/metrics
+      - "9090:9090" # Prometheus metrics:
+        #   http://localhost:9090/metrics
       - "18080:18080" # GatewayD HTTP gateway:
-                      #   http://localhost:18080/swagger-ui/ for the API documentation
-                      #   http://localhost:18080/healthz for the health check
+        #   http://localhost:18080/swagger-ui/ for the API documentation
+        #   http://localhost:18080/healthz for the health check
       - "19090:19090" # GatewayD gRPC API with reflection enabled:
-                      #   You can use grpcurl or grpc-client-cli to interact with it
+        #   You can use grpcurl or grpc-client-cli to interact with it
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
     links:

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,10 @@
 # This script is used to install the required packages and download
 # the latest version of GatewayD from GitHub and install the plugins.
 
+# Set the architecture to amd64 if it is not set
+[ -z "${ARCH}" ] && ARCH="amd64" && export ARCH
+echo "Using architecture: ${ARCH}"
+
 # Install the required packages
 apk add --no-cache curl git
 
@@ -28,8 +32,8 @@ echo "Installing GatewayD ${GATEWAYD_VERSION}"
 cd "${GATEWAYD_FILES}" || exit 127
 
 # Download the GatewayD archive if it doesn't exist
-[ -f "${GATEWAYD_FILES}"/gatewayd-linux-amd64-"${GATEWAYD_VERSION}".tar.gz ] || curl -L https://github.com/gatewayd-io/gatewayd/releases/download/"${GATEWAYD_VERSION}"/gatewayd-linux-amd64-"${GATEWAYD_VERSION}".tar.gz -o gatewayd-linux-amd64-"${GATEWAYD_VERSION}".tar.gz
-if [ -f "${GATEWAYD_FILES}"/gatewayd-linux-amd64-"${GATEWAYD_VERSION}".tar.gz ]; then
+[ -f "${GATEWAYD_FILES}"/gatewayd-linux-"${ARCH}"-"${GATEWAYD_VERSION}".tar.gz ] || curl -L https://github.com/gatewayd-io/gatewayd/releases/download/"${GATEWAYD_VERSION}"/gatewayd-linux-"${ARCH}"-"${GATEWAYD_VERSION}".tar.gz -o gatewayd-linux-"${ARCH}"-"${GATEWAYD_VERSION}".tar.gz
+if [ -f "${GATEWAYD_FILES}"/gatewayd-linux-"${ARCH}"-"${GATEWAYD_VERSION}".tar.gz ]; then
     echo "GatewayD archive downloaded successfully."
 else
     echo "GatewayD archive download failed."
@@ -38,7 +42,7 @@ fi
 
 # Extract the GatewayD archive
 echo "Extracting GatewayD archive..."
-tar zxvf gatewayd-linux-amd64-"${GATEWAYD_VERSION}".tar.gz -C "${GATEWAYD_FILES}"
+tar zxvf gatewayd-linux-"${ARCH}"-"${GATEWAYD_VERSION}".tar.gz -C "${GATEWAYD_FILES}"
 
 # Set execute permission for the GatewayD binary
 echo "Setting execute permission for the GatewayD binary..."

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,16 @@
 # the latest version of GatewayD from GitHub and install the plugins.
 
 # Set the architecture to amd64 if it is not set
-[ -z "${ARCH}" ] && ARCH="amd64" && export ARCH
+if [ -z "${ARCH}" ]; then
+    architecture=$(uname -m)
+    if [[ "${architecture}" = "x86_64" ]]; then
+        echo "Setting architecture to amd64"
+        ARCH=amd64 && export ARCH
+    elif [[ "${architecture}" = "aarch64" ]] || [[ "${architecture}" = "arm64" ]]; then
+        echo "Setting architecture to arm64"
+        ARCH=arm64 && export ARCH
+    fi
+fi
 echo "Using architecture: ${ARCH}"
 
 # Install the required packages


### PR DESCRIPTION
# Ticket(s)

Fixes #537.

## Description

In this PR I tried to address the issues raised in #537:

1. Git is now installed prior to setting the `GATEWAYD_VERSION` env-var.
2. There is a new env-var, `ARCH`, that can be used to set the architecture of GatewayD and plugins to install and it accepts two values `amd64` (default) or `arm64`. Otherwise it'll be set automatically using `uname -m` command.
3. Improved exit codes based on [this link](https://komodor.com/learn/exit-codes-in-containers-and-kubernetes-the-complete-guide/), and added comments and logs, so that it's easier to spot the issue.

@sinadarbouy would be happy if you could test this PR and confirm that it works as expected. 🙏 Then, I'll merge it.
@hamedsalim1999 would be happy to have your feedback as well.

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
