### PR TITLE
Use `REDIS_URL` to set up the cache plugin

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       # Default: amd64
       # Possible values: amd64 or arm64
       - ARCH=amd64
+      - REDIS_URL=redis://redis:6379/0
   postgres:
     image: postgres:latest
     environment:

--- a/setup.sh
+++ b/setup.sh
@@ -63,6 +63,8 @@ echo "Installing GatewayD plugins..."
 "${GATEWAYD_FILES}"/gatewayd plugin install --skip-path-slip-verification --output-dir "${GATEWAYD_FILES}" --plugin-config "${GATEWAYD_FILES}"/gatewayd_plugins.yaml --cleanup=false --update --overwrite-config || exit 126
 
 # Replace the default Redis URL with the Redis container URL
-sed -i 's/redis:\/\/localhost:6379/redis:\/\/redis:6379/' "${GATEWAYD_FILES}"/gatewayd_plugins.yaml
+[ -z "${REDIS_URL}" ] && REDIS_URL="redis://redis:6379/0" && export REDIS_URL
+echo "Setting Redis URL to ${REDIS_URL}"
+sed -i "s#redis://localhost:6379/0#${REDIS_URL}#" "${GATEWAYD_FILES}"/gatewayd_plugins.yaml
 
 echo "GatewayD ${GATEWAYD_VERSION} and plugins installed successfully. Exiting..."


### PR DESCRIPTION
# Ticket(s)

Fixes #537.

## Description

This PR address this https://github.com/gatewayd-io/gatewayd/pull/538#discussion_r1611270324 by introducing a `REDIS_URL` to configure the cache plugin.

@hamedsalim1999 Is this how you imagined doing this?

## Related PRs

- #538

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
