### PR TITLE
Enrich policy input

### DIFF
--- a/act/registry_test.go
+++ b/act/registry_test.go
@@ -196,9 +196,17 @@ func Test_Apply(t *testing.T) {
 		})
 	assert.NotNil(t, actRegistry)
 
-	outputs := actRegistry.Apply([]sdkAct.Signal{
-		*sdkAct.Passthrough(),
-	})
+	outputs := actRegistry.Apply(
+		[]sdkAct.Signal{
+			*sdkAct.Passthrough(),
+		},
+		sdkAct.Hook{
+			Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+			Priority: 1000,
+			Params:   map[string]any{},
+			Result:   map[string]any{},
+		},
+	)
 	assert.NotNil(t, outputs)
 	assert.Len(t, outputs, 1)
 	assert.Equal(t, "passthrough", outputs[0].MatchedPolicy)
@@ -225,7 +233,15 @@ func Test_Apply_NoSignals(t *testing.T) {
 		})
 	assert.NotNil(t, actRegistry)
 
-	outputs := actRegistry.Apply([]sdkAct.Signal{})
+	outputs := actRegistry.Apply(
+		[]sdkAct.Signal{},
+		sdkAct.Hook{
+			Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+			Priority: 1000,
+			Params:   map[string]any{},
+			Result:   map[string]any{},
+		},
+	)
 	assert.NotNil(t, outputs)
 	assert.Len(t, outputs, 1)
 	assert.Equal(t, "passthrough", outputs[0].MatchedPolicy)
@@ -272,7 +288,12 @@ func Test_Apply_ContradictorySignals(t *testing.T) {
 	assert.NotNil(t, actRegistry)
 
 	for _, s := range signals {
-		outputs := actRegistry.Apply(s)
+		outputs := actRegistry.Apply(s, sdkAct.Hook{
+			Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+			Priority: 1000,
+			Params:   map[string]any{},
+			Result:   map[string]any{},
+		})
 		assert.NotNil(t, outputs)
 		assert.Len(t, outputs, 2)
 		assert.Equal(t, "terminate", outputs[0].MatchedPolicy)
@@ -318,6 +339,11 @@ func Test_Apply_ActionNotMatched(t *testing.T) {
 
 	outputs := actRegistry.Apply([]sdkAct.Signal{
 		{Name: "non-existent"},
+	}, sdkAct.Hook{
+		Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+		Priority: 1000,
+		Params:   map[string]any{},
+		Result:   map[string]any{},
 	})
 	assert.NotNil(t, outputs)
 	assert.Len(t, outputs, 1)
@@ -351,6 +377,11 @@ func Test_Apply_PolicyNotMatched(t *testing.T) {
 
 	outputs := actRegistry.Apply([]sdkAct.Signal{
 		*sdkAct.Terminate(),
+	}, sdkAct.Hook{
+		Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+		Priority: 1000,
+		Params:   map[string]any{},
+		Result:   map[string]any{},
 	})
 	assert.NotNil(t, outputs)
 	assert.Len(t, outputs, 1)
@@ -399,6 +430,11 @@ func Test_Apply_NonBoolPolicy(t *testing.T) {
 
 		outputs := actRegistry.Apply([]sdkAct.Signal{
 			*sdkAct.Passthrough(),
+		}, sdkAct.Hook{
+			Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+			Priority: 1000,
+			Params:   map[string]any{},
+			Result:   map[string]any{},
 		})
 		assert.NotNil(t, outputs)
 		assert.Len(t, outputs, 1)
@@ -464,6 +500,11 @@ func Test_Run(t *testing.T) {
 
 	outputs := actRegistry.Apply([]sdkAct.Signal{
 		*sdkAct.Passthrough(),
+	}, sdkAct.Hook{
+		Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+		Priority: 1000,
+		Params:   map[string]any{},
+		Result:   map[string]any{},
 	})
 	assert.NotNil(t, outputs)
 
@@ -489,6 +530,11 @@ func Test_Run_Terminate(t *testing.T) {
 
 	outputs := actRegistry.Apply([]sdkAct.Signal{
 		*sdkAct.Terminate(),
+	}, sdkAct.Hook{
+		Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+		Priority: 1000,
+		Params:   map[string]any{},
+		Result:   map[string]any{},
 	})
 	assert.NotNil(t, outputs)
 	assert.Equal(t, "terminate", outputs[0].MatchedPolicy)
@@ -522,6 +568,11 @@ func Test_Run_Async(t *testing.T) {
 
 	outputs := actRegistry.Apply([]sdkAct.Signal{
 		*sdkAct.Log("info", "test", map[string]any{"async": true}),
+	}, sdkAct.Hook{
+		Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+		Priority: 1000,
+		Params:   map[string]any{},
+		Result:   map[string]any{},
 	})
 	assert.NotNil(t, outputs)
 	assert.Equal(t, "log", outputs[0].MatchedPolicy)
@@ -647,7 +698,15 @@ func Test_Run_Timeout(t *testing.T) {
 				})
 			assert.NotNil(t, actRegistry)
 
-			outputs := actRegistry.Apply([]sdkAct.Signal{*signals[name]})
+			outputs := actRegistry.Apply(
+				[]sdkAct.Signal{*signals[name]},
+				sdkAct.Hook{
+					Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+					Priority: 1000,
+					Params:   map[string]any{},
+					Result:   map[string]any{},
+				},
+			)
 			assert.NotNil(t, outputs)
 			assert.Equal(t, name, outputs[0].MatchedPolicy)
 			assert.Equal(t,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/codingsince1985/checksum v1.3.0
 	github.com/cybercyst/go-scaffold v0.0.0-20240404115540-744e601147cd
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
-	github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.13
+	github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.14
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-co-op/gocron v1.37.0
 	github.com/google/go-github/v53 v53.2.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.13 h1:zjsMK6m/DwaD8vHmPDKhMyhUuWlRzF4Y8FO3hNmujZg=
-github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.13/go.mod h1:TN8dII/sN3awR0znv2vY25rhHLN9XyMTNnEIUWjioMk=
+github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.14 h1:h1lw4Hw0ugF+dOC2ytbEQA2exfZreLutR79+nBFLYSg=
+github.com/gatewayd-io/gatewayd-plugin-sdk v0.2.14/go.mod h1:TN8dII/sN3awR0znv2vY25rhHLN9XyMTNnEIUWjioMk=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/plugin/plugin_registry.go
+++ b/plugin/plugin_registry.go
@@ -373,7 +373,7 @@ func (reg *Registry) Apply(hookName string, result *v1.Struct) ([]*sdkAct.Output
 	// Check if any of the policies have a terminal action.
 	var terminal bool
 	for _, output := range outputs {
-		if output.Verdict != nil && output.Terminal {
+		if output.Verdict != nil && cast.ToBool(output.Verdict) && output.Terminal {
 			terminal = true
 			break
 		}

--- a/plugin/utils.go
+++ b/plugin/utils.go
@@ -76,7 +76,10 @@ func getSignals(result map[string]any) []sdkAct.Signal {
 
 // applyPolicies applies the policies to the signals and returns the outputs.
 func applyPolicies(
-	hookName string, signals []sdkAct.Signal, logger zerolog.Logger, reg act.IRegistry,
+	hook sdkAct.Hook,
+	signals []sdkAct.Signal,
+	logger zerolog.Logger,
+	reg act.IRegistry,
 ) []*sdkAct.Output {
 	signalNames := []string{}
 	for _, signal := range signals {
@@ -85,15 +88,15 @@ func applyPolicies(
 
 	logger.Debug().Fields(
 		map[string]interface{}{
-			"hook":    hookName,
+			"hook":    hook.Name,
 			"signals": signalNames,
 		},
 	).Msg("Detected signals from the plugin hook")
 
-	outputs := reg.Apply(signals)
+	outputs := reg.Apply(signals, hook)
 	logger.Debug().Fields(
 		map[string]interface{}{
-			"hook":    hookName,
+			"hook":    hook.Name,
 			"outputs": outputs,
 		},
 	).Msg("Applied policies to signals")

--- a/plugin/utils_test.go
+++ b/plugin/utils_test.go
@@ -102,7 +102,16 @@ func Test_applyPolicies(t *testing.T) {
 		})
 
 	output := applyPolicies(
-		"onTrafficFromClient", []sdkAct.Signal{*sdkAct.Passthrough()}, logger, actRegistry)
+		sdkAct.Hook{
+			Name:     "HOOK_NAME_ON_TRAFFIC_FROM_CLIENT",
+			Priority: 1000,
+			Params:   map[string]any{},
+			Result:   map[string]any{},
+		},
+		[]sdkAct.Signal{*sdkAct.Passthrough()},
+		logger,
+		actRegistry,
+	)
 	assert.Len(t, output, 1)
 	assert.Equal(t, "passthrough", output[0].MatchedPolicy)
 	assert.Nil(t, output[0].Metadata)


### PR DESCRIPTION
# Ticket(s)

Closes #462.

## Description

This PR adds hook information to the policy `Input` data. This adds yet another piece of information that can be leveraged by policies with better granularity. These are now passed to the policies:

1. `Hook.Name`: the name of the plugin hook that was run and received the Act signals.
2. `Hook.Priority`: the priority of the plugin hook. This shows at which point from the top of the list of registered hook the plugin hook was called from.
3. `Hook.Params`: the parameters passed to the plugin hook.
4. `Hook.Result`: the result of running the plugin hook. This is usually a superset of the `Hook.Params`, because the plugin hook _must_ return the same request that was passed to it by the `Hook.Params`.

This feature will work with all the future signals, policies and actions and will enable a lot of interesting use cases. For example, these initial scenarios and policies can be written after merging this PR:

1. The current [`terminate`](https://github.com/gatewayd-io/gatewayd/blob/94a747f61e97944865c22e851cf03a3ed1f8cb49/act/builtins.go#L38-L42) policy can be updated to check for IP address of the incoming client or outgoing connection to the database. The example below means that terminating the request only happens if the request isn't coming from `127.0.0.1` (`localhost`). Note that the [`trafficData`](https://github.com/gatewayd-io/gatewayd/blob/94a747f61e97944865c22e851cf03a3ed1f8cb49/network/utils.go#L51-L91) internal help function injects these values into the parameters that are passed to the plugin hook.
    ```yaml
    policies:
      - name: terminate
        policy: |
          Signal.terminate == true &&
          Policy.terminate == 'stop' &&
          split(Hook.Params.client.remote, ':')[0] != '127.0.0.1'
        metadata:
          terminate: "stop"
    ```
2. We might want to terminate a request, but only log an audit trail (as an error) if the request doesn't come from an specific IP address:
    ```yaml
    policies:
      - name: log
        policy: |
          Signal.log == true &&
          Policy.log == 'log' &&
          split(Hook.Params.client.remote, ':')[0] != '192.168.0.1'
        metadata:
          log: "log"
    ```

## TODO

- [ ] Update docs
- [ ] Create helper functions to make writing policies easier

## Related PRs

- https://github.com/gatewayd-io/gatewayd-plugin-sdk/pull/33

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
