### PR TITLE
Fix IP Address Binding Issue to Allow External Access from Host Machine

### DIFF
--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -23,7 +23,7 @@ loggers:
 metrics:
   default:
     enabled: True
-    address: localhost:9090
+    address: 0.0.0.0:9090
     path: /metrics
     readHeaderTimeout: 10s # duration, prevents Slowloris attacks
     timeout: 10s # duration
@@ -68,6 +68,6 @@ servers:
 
 api:
   enabled: True
-  httpAddress: localhost:18080
+  httpAddress: 0.0.0.0:18080
   grpcNetwork: tcp
-  grpcAddress: localhost:19090
+  grpcAddress: 0.0.0.0:19090


### PR DESCRIPTION
# Ticket(s)
https://github.com/gatewayd-io/gatewayd/issues/551

## Description
This pull request addresses an issue with the application's IP address binding configuration that prevents it from being accessible from the host machine when running in a Docker container. The application was previously configured to listen on `localhost`, which restricts access to within the container itself. By changing the configuration to bind to `0.0.0.0`, the application will now listen on all available network interfaces, making it accessible from the host machine.