### PR TITLE
Changed the log level for plugin startup failures from debug to error

### DIFF
--- a/plugin/plugin_registry.go
+++ b/plugin/plugin_registry.go
@@ -503,7 +503,7 @@ func (reg *Registry) LoadPlugins(
 
 		reg.Logger.Debug().Str("name", plugin.ID.Name).Msg("Plugin loaded")
 		if _, err := plugin.Start(); err != nil {
-			reg.Logger.Debug().Str("name", plugin.ID.Name).Err(err).Msg(
+			reg.Logger.Error().Str("name", plugin.ID.Name).Err(err).Msg(
 				"Failed to start plugin")
 			plugin.Client.Kill()
 			continue


### PR DESCRIPTION
# Ticket(s)
https://github.com/gatewayd-io/gatewayd/issues/559
## Description
The expected behavior is that if the plugin fails to start, the log message should be at the ERR level, ensuring it is visible even outside of Debug mode.