### PR TITLE
Remove the enforced value of the ARCH in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       # The architecture of the GatewayD and plugins to install.
       # Default: amd64
       # Possible values: amd64 or arm64
-      - ARCH=amd64
+      # - ARCH=amd64
       - REDIS_URL=redis://redis:6379/0
   postgres:
     image: postgres:latest
@@ -38,14 +38,7 @@ services:
       retries: 5
   gatewayd:
     image: gatewaydio/gatewayd:latest
-    command:
-      [
-        "run",
-        "--config",
-        "/gatewayd-files/gatewayd.yaml",
-        "--plugin-config",
-        "/gatewayd-files/gatewayd_plugins.yaml",
-      ]
+    command: ["run", "--config", "/gatewayd-files/gatewayd.yaml", "--plugin-config", "/gatewayd-files/gatewayd_plugins.yaml"]
     environment:
       # For more information about the environment variables, see:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables


### PR DESCRIPTION
# Ticket(s)
Closes #553 

## Description
The `setup.sh` is already evaluating the CPU architecture. Hence, enforcing the ARCH value is not necessary.


<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
