### PR TITLE
Bugfix/workflow vulnerability comparison

### DIFF
--- a/.github/workflows/vulnerability-comparison.yaml
+++ b/.github/workflows/vulnerability-comparison.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   vulnerability-comparison:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/vulnerability-comparison.yaml
+++ b/.github/workflows/vulnerability-comparison.yaml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ env.SHA }}
       - name: Set short SHA
         id: vars
-        run: echo "SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
+        run: echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image


### PR DESCRIPTION
I've created this bugfix PR to fix the workflow `short hash tag` and the `rule` for when the PR runs. 

To avoid having a failed job when we have a PR, I've created this bugfix to only run the job if it's from the `gateway repository`. This will be in place until we find the best practice for using secrets in our pull requests from forked repositories.