### PR TITLE
add Tempo, Prometheus and Grafana to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ cmd/docs/*
 # docker-compose
 gatewayd-files/
 cmd/gatewayd-plugin-cache-linux-amd64-*
+tempo-data
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       retries: 5
   gatewayd:
     image: gatewaydio/gatewayd:latest
-    command: ["run", "--config", "/gatewayd-files/gatewayd.yaml", "--plugin-config", "/gatewayd-files/gatewayd_plugins.yaml"]
+    command: ["run", "--config", "/gatewayd-files/gatewayd.yaml", "--plugin-config", "/gatewayd-files/gatewayd_plugins.yaml", "--tracing", "--collector-url", "tempo:4317"]
     environment:
       # For more information about the environment variables, see:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables
@@ -48,8 +48,8 @@ services:
       # GatewayD server for PostgreSQL clients to connect to
       - "15432:15432"
       # Prometheus metrics:
-      #   http://localhost:9090/metrics
-      - "9090:9090"
+      #   http://localhost:9090/metrics # Make sure the port is not used by prometheus before uncommenting the following line
+      # - "9090:9090"
       # GatewayD HTTP gateway:
       #   http://localhost:18080/swagger-ui/ for the API documentation
       #   http://localhost:18080/healthz for the health check
@@ -74,3 +74,47 @@ services:
         condition: service_healthy
       install_plugins:
         condition: service_completed_successfully
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./observability-configs/prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - gatewayd
+
+  tempo_init:
+    image: &tempoImage grafana/tempo:latest
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - ./tempo-data:/var/tempo
+
+  tempo:
+    image: *tempoImage
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./observability-configs/tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data:/var/tempo
+    ports:
+      - "4317:4317" # otlp grpc
+    depends_on:
+      - tempo_init
+
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - ./observability-configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - tempo

--- a/observability-configs/grafana-datasources.yaml
+++ b/observability-configs/grafana-datasources.yaml
@@ -1,0 +1,31 @@
+apiVersion: 1
+
+datasources:
+  - name: GatewayD Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    jsonData:
+      httpMethod: GET
+  - name: GatewayD Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    uid: tempo
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+

--- a/observability-configs/prometheus.yaml
+++ b/observability-configs/prometheus.yaml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "gatewayd-aggregated-metrics"
+    scrape_interval: 5s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["gatewayd:9090"]
+
+  - job_name: "tempo"
+    static_configs:
+      - targets: ["tempo:3200"]

--- a/observability-configs/tempo.yaml
+++ b/observability-configs/tempo.yaml
@@ -1,0 +1,43 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers: # this configuration will listen on all ports and protocols that tempo is capable of.
+    otlp:
+      protocols:
+        grpc:
+
+ingester:
+  max_block_duration: 5m # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h # overall Tempo trace retention. set for demo purposes
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+
+storage:
+  trace:
+    backend: local # backend configuration to use
+    wal:
+      path: /var/tempo/wal # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator


### PR DESCRIPTION
# Ticket

Closes #487

## Description
I've added the config files needed for Temp, Proemtheus and Grafana (datasources) and updated the docker-compose file to start them. The authentication is intentionally skipped to make it easier for local use. 

I've also updated the docker-compose to build the docker file locally and start the container based on the built image. I'm open to further discuss it, but here are my trail of thoughts:
1. I've been troubled using the pushed version of gatewayd image as stated in #568.
2. It would be easier for developers to work with the observability tools and other external services such as Postgres and Redis while developing the service, if the container is created based on the code in the development branch. In other words, having the container built based on the under-development code will facilitate the process of local-development  

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
