### PR TITLE
Fix/env vars expect lower case letters

### DIFF
--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -80,6 +80,9 @@ func lintConfig(fileType configFileType, configFile string) *gerr.GatewayDError 
 		if err := conf.LoadGlobalConfigFile(context.TODO()); err != nil {
 			return err
 		}
+		if err := conf.ConvertKeysToLowercase(context.TODO()); err != nil {
+			return err
+		}
 		if err := conf.UnmarshalGlobalConfig(context.TODO()); err != nil {
 			return err
 		}

--- a/cmd/testdata/gatewayd.yaml
+++ b/cmd/testdata/gatewayd.yaml
@@ -18,7 +18,7 @@ metrics:
 
 clients:
   default:
-    active-writes:
+    writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -51,7 +51,7 @@ clients:
 
 pools:
   default:
-    active-writes:
+    writes:
       size: 10
   test:
     write:
@@ -59,7 +59,7 @@ pools:
 
 proxies:
   default:
-    active-writes:
+    writes:
       healthCheckPeriod: 60s # duration
   test:
     write:

--- a/cmd/testdata/gatewayd.yaml
+++ b/cmd/testdata/gatewayd.yaml
@@ -18,7 +18,7 @@ metrics:
 
 clients:
   default:
-    activeWrites:
+    active-writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -51,7 +51,7 @@ clients:
 
 pools:
   default:
-    activeWrites:
+    active-writes:
       size: 10
   test:
     write:
@@ -59,7 +59,7 @@ pools:
 
 proxies:
   default:
-    activeWrites:
+    active-writes:
       healthCheckPeriod: 60s # duration
   test:
     write:

--- a/cmd/testdata/gatewayd_tls.yaml
+++ b/cmd/testdata/gatewayd_tls.yaml
@@ -12,7 +12,7 @@ metrics:
 
 clients:
   default:
-    active-writes:
+    writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -29,12 +29,12 @@ clients:
 
 pools:
   default:
-    active-writes:
+    writes:
       size: 10
 
 proxies:
   default:
-    active-writes:
+    writes:
       healthCheckPeriod: 60s # duration
 
 servers:

--- a/cmd/testdata/gatewayd_tls.yaml
+++ b/cmd/testdata/gatewayd_tls.yaml
@@ -12,7 +12,7 @@ metrics:
 
 clients:
   default:
-    activeWrites:
+    active-writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -29,12 +29,12 @@ clients:
 
 pools:
   default:
-    activeWrites:
+    active-writes:
       size: 10
 
 proxies:
   default:
-    activeWrites:
+    active-writes:
       healthCheckPeriod: 60s # duration
 
 servers:

--- a/config/config.go
+++ b/config/config.go
@@ -478,8 +478,8 @@ func (c *Config) MergeGlobalConfig(
 func convertMapKeysToLowercase[T any](m map[string]*T) map[string]*T {
 	newMap := make(map[string]*T)
 	for k, v := range m {
-		lowerKey := strings.ToLower(k)
-		newMap[lowerKey] = v
+		lowercaseKey := strings.ToLower(k)
+		newMap[lowercaseKey] = v
 	}
 	return newMap
 }
@@ -494,8 +494,8 @@ func convertMapKeysToLowercase[T any](m map[string]*T) map[string]*T {
 func convertNestedMapKeysToLowercase[T any](m map[string]map[string]*T) map[string]map[string]*T {
 	newMap := make(map[string]map[string]*T)
 	for k, v := range m {
-		lowerKey := strings.ToLower(k)
-		newMap[lowerKey] = convertMapKeysToLowercase(v)
+		lowercaseKey := strings.ToLower(k)
+		newMap[lowercaseKey] = convertMapKeysToLowercase(v)
 	}
 	return newMap
 }

--- a/config/config.go
+++ b/config/config.go
@@ -630,7 +630,7 @@ func (c *Config) ValidateGlobalConfig(ctx context.Context) *gerr.GatewayDError {
 		for configBlockName := range configGroups {
 			clientConfigGroups[configGroupName][configBlockName] = true
 			if globalConfig.Clients[configGroupName][configBlockName] == nil {
-				err := fmt.Errorf("\"clients.%s\" is nil or empty", configBlockName)
+				err := fmt.Errorf(`"clients.%s" is nil or empty`, configBlockName)
 				span.RecordError(err)
 				errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -553,15 +553,18 @@ func (c *Config) ConvertKeysToLowercase(ctx context.Context) *gerr.GatewayDError
 	return nil
 }
 
-// Helper function to convert a struct to a map[string]interface{}
+// structToMap converts a given struct to a map[string]interface{}.
 func structToMap(v interface{}) (map[string]interface{}, error) {
 	var result map[string]interface{}
 	data, err := json.Marshal(v)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal struct: %w", err)
 	}
 	err = json.Unmarshal(data, &result)
-	return result, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal data into map: %w", err)
+	}
+	return result, nil
 }
 
 func (c *Config) ValidateGlobalConfig(ctx context.Context) *gerr.GatewayDError {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -188,6 +188,28 @@ func pluginDefaultPolicyOverwrite(t *testing.T) {
 	assert.Equal(t, "test", config.Plugin.DefaultPolicy)
 }
 
+// clientNetworkOverwrite sets the environment variable for client network configuration
+// and verifies that the configuration is correctly loaded with the expected value.
+func clientNetworkOverwrite(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_ACTIVE-WRITES_NETWORK", "udp")
+	config := initializeConfig(ctx, t)
+	assert.Equal(t, "udp", config.Global.Clients[Default][DefaultConfigurationBlock].Network)
+}
+
+// serverNetworkOverwrite sets the environment variable for server network configuration
+// and verifies that the configuration is correctly loaded with the expected value.
+func serverNetworkOverwrite(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Setenv("GATEWAYD_SERVERS_DEFAULT_NETWORK", "udp")
+	config := initializeConfig(ctx, t)
+	assert.Equal(t, "udp", config.Global.Servers[Default].Network)
+}
+
 // TestLoadEnvVariables runs a suite of tests to verify that environment variables are correctly
 // loaded into the configuration. Each test scenario sets a specific environment variable and
 // checks if the configuration reflects the expected value.
@@ -195,6 +217,8 @@ func TestLoadEnvVariables(t *testing.T) {
 	scenarios := map[string]func(t *testing.T){
 		"serverLoadBalancerStrategyOverwrite": ServerLoadBalancerStrategyOverwrite,
 		"pluginLocalPathOverwrite":            pluginDefaultPolicyOverwrite,
+		"ClientNetworkOverwrite":              clientNetworkOverwrite,
+		"ServerNetworkOverwrite":              serverNetworkOverwrite,
 	}
 
 	for scenario, fn := range scenarios {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,11 +194,11 @@ func clientNetworkOverwrite(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 	// Convert to uppercase
-	upperDefaultConfigurationGroup := strings.ToUpper(Default)
-	upperDefaultConfigurationBlock := strings.ToUpper(DefaultConfigurationBlock)
+	upperDefaultGroup := strings.ToUpper(Default)
+	upperDefaultBlock := strings.ToUpper(DefaultConfigurationBlock)
 
 	// Format environment variable name
-	envVarName := fmt.Sprintf("GATEWAYD_CLIENTS_%s_%s_NETWORK", upperDefaultConfigurationGroup, upperDefaultConfigurationBlock)
+	envVarName := fmt.Sprintf("GATEWAYD_CLIENTS_%s_%s_NETWORK", upperDefaultGroup, upperDefaultBlock)
 
 	// Set the environment variable
 	t.Setenv(envVarName, "udp")
@@ -212,10 +212,10 @@ func serverNetworkOverwrite(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 	// Convert to uppercase
-	upperDefaultConfigurationGroup := strings.ToUpper(Default)
+	upperDefaultGroup := strings.ToUpper(Default)
 
 	// Format environment variable name
-	envVarName := fmt.Sprintf("GATEWAYD_SERVERS_%s_NETWORK", upperDefaultConfigurationGroup)
+	envVarName := fmt.Sprintf("GATEWAYD_SERVERS_%s_NETWORK", upperDefaultGroup)
 
 	// Set the environment variable
 	t.Setenv(envVarName, "udp")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -193,8 +193,15 @@ func pluginDefaultPolicyOverwrite(t *testing.T) {
 func clientNetworkOverwrite(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
+	// Convert to uppercase
+	upperDefaultConfigurationGroup := strings.ToUpper(Default)
+	upperDefaultConfigurationBlock := strings.ToUpper(DefaultConfigurationBlock)
 
-	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_ACTIVE-WRITES_NETWORK", "udp")
+	// Format environment variable name
+	envVarName := fmt.Sprintf("GATEWAYD_CLIENTS_%s_%s_NETWORK", upperDefaultConfigurationGroup, upperDefaultConfigurationBlock)
+
+	// Set the environment variable
+	t.Setenv(envVarName, "udp")
 	config := initializeConfig(ctx, t)
 	assert.Equal(t, "udp", config.Global.Clients[Default][DefaultConfigurationBlock].Network)
 }
@@ -204,8 +211,14 @@ func clientNetworkOverwrite(t *testing.T) {
 func serverNetworkOverwrite(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
+	// Convert to uppercase
+	upperDefaultConfigurationGroup := strings.ToUpper(Default)
 
-	t.Setenv("GATEWAYD_SERVERS_DEFAULT_NETWORK", "udp")
+	// Format environment variable name
+	envVarName := fmt.Sprintf("GATEWAYD_SERVERS_%s_NETWORK", upperDefaultConfigurationGroup)
+
+	// Set the environment variable
+	t.Setenv(envVarName, "udp")
 	config := initializeConfig(ctx, t)
 	assert.Equal(t, "udp", config.Global.Servers[Default].Network)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,3 +227,20 @@ func TestLoadEnvVariables(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertKeysToLowercaseSuccess verifies that after calling ConvertKeysToLowercase,
+// all keys in the config.Global.Clients map are converted to lowercase.
+func TestConvertKeysToLowercaseSuccess(t *testing.T) {
+	ctx := context.Background()
+	config := NewConfig(ctx,
+		Config{GlobalConfigFile: parentDir + GlobalConfigFilename, PluginConfigFile: parentDir + PluginsConfigFilename})
+
+	err := config.ConvertKeysToLowercase(ctx)
+	require.Nil(t, err)
+	for configurationGroupName, configurationGroup := range config.Global.Clients {
+		assert.Equal(t, configurationGroupName, strings.ToLower(configurationGroupName))
+		for configuraionBlockName := range configurationGroup {
+			assert.Equal(t, configuraionBlockName, strings.ToLower(configuraionBlockName))
+		}
+	}
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -35,7 +35,7 @@ const (
 const (
 	// Config constants.
 	Default                   = "default"
-	DefaultConfigurationBlock = "activeWrites"
+	DefaultConfigurationBlock = "active-writes"
 	EnvPrefix                 = "GATEWAYD_"
 	TracerName                = "gatewayd"
 	GlobalConfigFilename      = "gatewayd.yaml"

--- a/config/constants.go
+++ b/config/constants.go
@@ -35,7 +35,7 @@ const (
 const (
 	// Config constants.
 	Default                   = "default"
-	DefaultConfigurationBlock = "active-writes"
+	DefaultConfigurationBlock = "writes"
 	EnvPrefix                 = "GATEWAYD_"
 	TracerName                = "gatewayd"
 	GlobalConfigFilename      = "gatewayd.yaml"

--- a/config/testdata/missing_keys.yaml
+++ b/config/testdata/missing_keys.yaml
@@ -20,7 +20,7 @@ metrics:
 
 clients:
   default:
-    activeWrites:
+    active-writes:
       address: localhost:5432
   test:
     write:
@@ -28,7 +28,7 @@ clients:
 
 pools:
   default:
-    activeWrites:
+    active-writes:
       size: 10
   test:
     write:
@@ -36,7 +36,7 @@ pools:
 
 proxies:
   default:
-    activeWrites:
+    active-writes:
       healthCheckPeriod: 60s # duration
   test:
     write:

--- a/config/testdata/missing_keys.yaml
+++ b/config/testdata/missing_keys.yaml
@@ -20,7 +20,7 @@ metrics:
 
 clients:
   default:
-    active-writes:
+    writes:
       address: localhost:5432
   test:
     write:
@@ -28,7 +28,7 @@ clients:
 
 pools:
   default:
-    active-writes:
+    writes:
       size: 10
   test:
     write:
@@ -36,7 +36,7 @@ pools:
 
 proxies:
   default:
-    active-writes:
+    writes:
       healthCheckPeriod: 60s # duration
   test:
     write:

--- a/errors/gatewayd_error.go
+++ b/errors/gatewayd_error.go
@@ -20,8 +20,11 @@ func (e *GatewayDError) Error() string {
 
 // Wrap wraps the original error.
 func (e *GatewayDError) Wrap(err error) *GatewayDError {
-	e.OriginalError = err
-	return e
+	return &GatewayDError{
+		Code:          e.Code,
+		Message:       e.Message,
+		OriginalError: err,
+	}
 }
 
 // Unwrap returns the original error.

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -32,7 +32,7 @@ metrics:
 
 clients:
   default:
-    activeWrites:
+    active-writes:
       network: tcp
       address: localhost:5432
       tcpKeepAlive: False
@@ -47,7 +47,7 @@ clients:
       backoff: 1s # duration
       backoffMultiplier: 2.0 # 0 means no backoff
       disableBackoffCaps: false
-    standbyReads:
+    standby-reads:
       network: tcp
       address: localhost:5433
       tcpKeepAlive: False
@@ -65,16 +65,16 @@ clients:
 
 pools:
   default:
-    activeWrites:
+    active-writes:
       size: 10
-    standbyReads:
+    standby-reads:
       size: 10
 
 proxies:
   default:
-    activeWrites:
+    active-writes:
       healthCheckPeriod: 60s # duration
-    standbyReads:
+    standby-reads:
       healthCheckPeriod: 60s # duration
 
 servers:

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -32,7 +32,7 @@ metrics:
 
 clients:
   default:
-    active-writes:
+    writes:
       network: tcp
       address: localhost:5432
       tcpKeepAlive: False
@@ -47,7 +47,7 @@ clients:
       backoff: 1s # duration
       backoffMultiplier: 2.0 # 0 means no backoff
       disableBackoffCaps: false
-    standby-reads:
+    reads:
       network: tcp
       address: localhost:5433
       tcpKeepAlive: False
@@ -65,16 +65,16 @@ clients:
 
 pools:
   default:
-    active-writes:
+    writes:
       size: 10
-    standby-reads:
+    reads:
       size: 10
 
 proxies:
   default:
-    active-writes:
+    writes:
       healthCheckPeriod: 60s # duration
-    standby-reads:
+    reads:
       healthCheckPeriod: 60s # duration
 
 servers:

--- a/testdata/gatewayd_tls.yaml
+++ b/testdata/gatewayd_tls.yaml
@@ -12,7 +12,7 @@ metrics:
 
 clients:
   default:
-    active-writes:
+    writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -29,12 +29,12 @@ clients:
 
 pools:
   default:
-    active-writes:
+    writes:
       size: 10
 
 proxies:
   default:
-    active-writes:
+    writes:
       healthCheckPeriod: 60s # duration
 
 servers:

--- a/testdata/gatewayd_tls.yaml
+++ b/testdata/gatewayd_tls.yaml
@@ -12,7 +12,7 @@ metrics:
 
 clients:
   default:
-    activeWrites:
+    active-writes:
       address: localhost:5432
       network: tcp
       tcpKeepAlive: False
@@ -29,12 +29,12 @@ clients:
 
 pools:
   default:
-    activeWrites:
+    active-writes:
       size: 10
 
 proxies:
   default:
-    activeWrites:
+    active-writes:
       healthCheckPeriod: 60s # duration
 
 servers:


### PR DESCRIPTION
# Ticket(s)
close #583 
## Description
This PR addresses an issue with the loadEnvVars() function where environment variables were being incorrectly processed due to the strings.ToLower function, which assumed all keys were in lowercase. Configuration blocks, however, use camel case (e.g., activeWrites), causing a mismatch.

- Implemented Key Conversion:
  - Added a new method, ConvertKeysToLowercase, which converts all keys in the global configuration to lowercase during the loading process, ensuring consistency.
- Updated Configuration Files:
  - Modified the configuration files (gatewayd.yaml, gatewayd_tls.yaml, missing_keys.yaml) to use lowercase keys (e.g., active-writes instead of `writes`).
- Validation Enhancements:
  - Enhanced the ValidateGlobalConfig method to ensure that all keys are lowercase.
  
 Found a bug when errors append into []*gerr.GatewayDError

> Previously, the code used a single instance of `GatewayDError` for all errors. This led to incorrect error messages because the same `GatewayDError` instance was being modified and appended to the slice, resulting in all errors appearing as if they had the same `OriginalError`.

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
