### PR TITLE
Fix parameters camelCase support in loadEnvVars for environment variable parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -626,7 +626,7 @@ func (c *Config) ValidateGlobalConfig(ctx context.Context) *gerr.GatewayDError {
 	return nil
 }
 
-// generateTagMapping generates a map of JSON tags to lower json tags.
+// generateTagMapping generates a map of JSON tags to lower case json tags.
 func generateTagMapping(structs []interface{}, tagMapping map[string]string) {
 	for _, s := range structs {
 		structValue := reflect.ValueOf(s).Elem()

--- a/config/config.go
+++ b/config/config.go
@@ -335,9 +335,40 @@ func (c *Config) LoadPluginEnvVars(ctx context.Context) *gerr.GatewayDError {
 }
 
 func loadEnvVars() *env.Env {
-	return env.Provider(EnvPrefix, ".", func(env string) string {
-		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(env, EnvPrefix)), "_", ".")
-	})
+	return env.Provider(EnvPrefix, ".", transformEnvVariable)
+}
+
+// transformEnvVariable transforms the environment variable name to a format based on JSON tags.
+func transformEnvVariable(envVar string) string {
+	structs := []interface{}{
+		&API{},
+		&Logger{},
+		&Pool{},
+		&Proxy{},
+		&Server{},
+		&Metrics{},
+		&PluginConfig{},
+	}
+	tagMapping := make(map[string]string)
+	generateTagMapping(structs, tagMapping)
+
+	lowerEnvVar := strings.ToLower(strings.TrimPrefix(envVar, EnvPrefix))
+	parts := strings.Split(lowerEnvVar, "_")
+
+	var transformedParts strings.Builder
+
+	for i, part := range parts {
+		if i > 0 {
+			transformedParts.WriteString(".")
+		}
+		if mappedValue, exists := tagMapping[part]; exists {
+			transformedParts.WriteString(mappedValue)
+		} else {
+			transformedParts.WriteString(part)
+		}
+	}
+
+	return transformedParts.String()
 }
 
 // LoadGlobalConfigFile loads the plugin configuration file.
@@ -593,4 +624,29 @@ func (c *Config) ValidateGlobalConfig(ctx context.Context) *gerr.GatewayDError {
 	span.End()
 
 	return nil
+}
+
+// generateTagMapping generates a map of JSON tags to lower json tags.
+func generateTagMapping(structs []interface{}, tagMapping map[string]string) {
+	for _, s := range structs {
+		structValue := reflect.ValueOf(s).Elem()
+		structType := structValue.Type()
+
+		for i := range structValue.NumField() {
+			field := structType.Field(i)
+			fieldValue := structValue.Field(i)
+
+			// Handle nested structs
+			if field.Type.Kind() == reflect.Struct {
+				generateTagMapping([]interface{}{fieldValue.Addr().Interface()}, tagMapping)
+			}
+
+			jsonTag := field.Tag.Get("json")
+			if jsonTag != "" {
+				tagMapping[strings.ToLower(jsonTag)] = jsonTag
+			} else {
+				tagMapping[strings.ToLower(field.Name)] = strings.ToLower(field.Name)
+			}
+		}
+	}
 }


### PR DESCRIPTION
# Ticket(s)
#583
## Description
This PR addresses a bug in the loadEnvVars function that prevented correct loading of environment variables when their names are in camelCase. The issue was caused by the function’s inability to transform camelCase environment variable names into the expected format for configuration.

Changes Made:

Updated loadEnvVars Function:
- Replaced the previous transformation logic with a new function, transformEnvVariable, which converts environment variable names based on JSON tags from relevant structs.

Introduced transformEnvVariable Function:
- This function transforms environment variable names to a format suitable for configuration by using a mapping derived from JSON tags of various structs.

Added generateTagMapping Function:
 - A helper function to generate a mapping of JSON tags to their lower-case versions. This is used by transformEnvVariable to correctly interpret environment variable names.
 
Expanded Test Coverage:
- Added tests to verify the correct loading of environment variables, including camelCase names. This ensures that changes in environment variable names are accurately reflected in the configuration.
- 
## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
