### PR TITLE
Add Multi-Proxy Support to Docker-Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,17 @@ services:
       # Possible values: amd64 or arm64
       # - ARCH=amd64
       - REDIS_URL=redis://redis:6379/0
-  postgres:
+  write-postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  read-postgres:
     image: postgres:latest
     environment:
       - POSTGRES_USER=postgres
@@ -42,7 +52,8 @@ services:
     environment:
       # For more information about the environment variables, see:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables
-      - GATEWAYD_CLIENTS_DEFAULT_ADDRESS=postgres:5432
+      - GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS=write-postgres:5432
+      - GATEWAYD_CLIENTS_DEFAULT_READS_ADDRESS=read-postgres:5432
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
       # GatewayD server for PostgreSQL clients to connect to
@@ -60,7 +71,8 @@ services:
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
     links:
-      - postgres
+      - write-postgres
+      - read-postgres
       - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://gatewayd:18080/healthz"]
@@ -68,7 +80,9 @@ services:
       timeout: 5s
       retries: 5
     depends_on:
-      postgres:
+      write-postgres:
+        condition: service_healthy
+      read-postgres:
         condition: service_healthy
       redis:
         condition: service_healthy


### PR DESCRIPTION
# Ticket(s)
N/A
## Description
This PR introduces changes to the docker-compose.yaml file to support multi-proxy configuration. The main changes are as follows:

Service Renaming and Addition:
- The existing postgres service has been renamed to `write-postgres` to clearly denote its role as the write database.
- A new `read-postgres` service has been added to handle read database operations.

Environment Variable Updates:
- Updated the gatewayd service environment variables to support separate addresses for read and write operations.
- New variables `GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS` and `GATEWAYD_CLIENTS_DEFAULT_READS_ADDRESS` have been introduced.

Configuration Changes:
- Updated the gatewayd service links to include both write-postgres and read-postgres.
- Modified the depends_on section to ensure both write-postgres and read-postgres are healthy before starting the gatewayd service.
## Related PRs

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
