### PR TITLE
Add Random Load Balancing Strategy

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -130,4 +130,5 @@ const (
 // Load balancing strategies.
 const (
 	RoundRobinStrategy = "ROUND_ROBIN"
+	RANDOMStrategy     = "RANDOM"
 )

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -83,7 +83,7 @@ servers:
     address: 0.0.0.0:15432
     loadBalancer:
       # Load balancer strategies can be found in config/constants.go
-      strategy: ROUND_ROBIN
+      strategy: RANDOM # ROUND_ROBIN, RANDOM
     enableTicker: False
     tickInterval: 5s # duration
     enableTLS: False

--- a/network/loadbalancer.go
+++ b/network/loadbalancer.go
@@ -13,6 +13,8 @@ func NewLoadBalancerStrategy(server *Server) (LoadBalancerStrategy, *gerr.Gatewa
 	switch server.LoadbalancerStrategyName {
 	case config.RoundRobinStrategy:
 		return NewRoundRobin(server), nil
+	case config.RANDOMStrategy:
+		return NewRandom(server), nil
 	default:
 		return nil, gerr.ErrLoadBalancerStrategyNotFound
 	}

--- a/network/random.go
+++ b/network/random.go
@@ -1,0 +1,52 @@
+package network
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+
+	gerr "github.com/gatewayd-io/gatewayd/errors"
+)
+
+// Random is a struct that holds a list of proxies and a mutex for thread safety.
+type Random struct {
+	mu      sync.Mutex
+	proxies []IProxy
+}
+
+// NewRandom creates a new Random instance with the given server's proxies.
+func NewRandom(server *Server) *Random {
+	return &Random{
+		proxies: server.Proxies,
+	}
+}
+
+// NextProxy returns a random proxy from the list.
+func (r *Random) NextProxy() (IProxy, *gerr.GatewayDError) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	proxiesLen := len(r.proxies)
+	if proxiesLen == 0 {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(errors.New("proxy list is empty"))
+	}
+
+	randomIndex, err := randInt(proxiesLen)
+	if err != nil {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
+	}
+
+	return r.proxies[randomIndex], nil
+}
+
+// randInt generates a random integer between 0 and max-1 using crypto/rand.
+func randInt(max int) (int, error) {
+	// Generate a secure random number
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate random integer: %w", err)
+	}
+	return int(n.Int64()), nil
+}

--- a/network/random_test.go
+++ b/network/random_test.go
@@ -1,0 +1,95 @@
+package network
+
+import (
+	"sync"
+	"testing"
+
+	gerr "github.com/gatewayd-io/gatewayd/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewRandom verifies that the NewRandom function properly initializes
+// a Random object with the provided server and its associated proxies.
+// The test ensures that the Random object is not nil and that the number of
+// proxies in the Random object matches the number of proxies in the Server.
+func TestNewRandom(t *testing.T) {
+	proxies := []IProxy{&MockProxy{}, &MockProxy{}}
+	server := &Server{Proxies: proxies}
+	random := NewRandom(server)
+
+	assert.NotNil(t, random)
+	assert.Equal(t, len(proxies), len(random.proxies))
+}
+
+// TestGetNextProxy checks the behavior of the NextProxy method in various
+// scenarios, including when proxies are available, when no proxies are available,
+// and the randomness of proxy selection.
+//
+// - The first sub-test confirms that NextProxy returns a valid proxy when available.
+// - The second sub-test ensures that an error is returned when there are no proxies available.
+// - The third sub-test checks if the proxy selection is random by comparing two subsequent calls.
+func TestGetNextProxy(t *testing.T) {
+	t.Run("Returns a proxy when proxies are available", func(t *testing.T) {
+		proxies := []IProxy{&MockProxy{}, &MockProxy{}}
+		server := &Server{Proxies: proxies}
+		random := NewRandom(server)
+
+		proxy, err := random.NextProxy()
+
+		assert.Nil(t, err)
+		assert.Contains(t, proxies, proxy)
+	})
+
+	t.Run("Returns error when no proxies are available", func(t *testing.T) {
+		server := &Server{Proxies: []IProxy{}}
+		random := NewRandom(server)
+
+		proxy, err := random.NextProxy()
+
+		assert.Nil(t, proxy)
+		assert.Equal(t, gerr.ErrNoProxiesAvailable.Message, err.Message)
+	})
+	t.Run("Random selection of proxies", func(t *testing.T) {
+		proxies := []IProxy{&MockProxy{}, &MockProxy{}}
+		server := &Server{Proxies: proxies}
+		random := NewRandom(server)
+
+		proxy1, _ := random.NextProxy()
+		proxy2, _ := random.NextProxy()
+
+		assert.Contains(t, proxies, proxy1)
+		assert.Contains(t, proxies, proxy2)
+		// It's possible that proxy1 and proxy2 are the same, but if we run this
+		// test enough times, they should occasionally be different.
+	})
+}
+
+// TestConcurrencySafety ensures that the Random object is safe for concurrent
+// use by multiple goroutines. The test launches multiple goroutines that
+// concurrently call the NextProxy method. It then verifies that all returned
+// proxies are part of the expected set of proxies, ensuring thread safety.
+func TestConcurrencySafety(t *testing.T) {
+	proxies := []IProxy{&MockProxy{}, &MockProxy{}}
+	server := &Server{Proxies: proxies}
+	random := NewRandom(server)
+
+	var waitGroup sync.WaitGroup
+	numGoroutines := 100
+	proxyChan := make(chan IProxy, numGoroutines)
+
+	for range numGoroutines {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			proxy, _ := random.NextProxy()
+			proxyChan <- proxy
+		}()
+	}
+
+	waitGroup.Wait()
+	close(proxyChan)
+
+	for proxy := range proxyChan {
+		assert.Contains(t, proxies, proxy)
+	}
+}


### PR DESCRIPTION
# Ticket(s)
https://github.com/gatewayd-io/gatewayd/issues/398
## Description
This PR introduces a new load balancing strategy, RANDOM
###  The key changes include
1.	Configuration Update:
- Added RANDOM as an option in the load balancing strategies within config/constants.go.
- Updated the gatewayd.yaml configuration file to support the new RANDOM strategy.
2.	Implementation of Random Load Balancer:
- Introduced a new Random struct in network/random.go, which selects proxies at random using a secure random number generator (crypto/rand).
- Implemented the NextProxy method, which safely selects a proxy in a thread-safe manner.
3.	Integration with Existing Load Balancer:
- Modified network/loadbalancer.go to handle the RANDOM strategy by invoking the NewRandom method.
4.	Testing:
- Added unit tests in network/random_test.go to validate the Random strategy’s functionality, including tests for proxy selection, error handling when no proxies are available, and concurrency safety.

## Related PRs

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
