### PR TITLE
Add Weighted Round Robin Algorithm to Load Balancer

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -851,6 +851,7 @@ var runCmd = &cobra.Command{
 				proxies[configGroupName][configBlockName] = network.NewProxy(
 					runCtx,
 					network.Proxy{
+						Name:                 configBlockName,
 						AvailableConnections: pools[configGroupName][configBlockName],
 						PluginRegistry:       pluginRegistry,
 						HealthCheckPeriod:    cfg.HealthCheckPeriod,
@@ -918,6 +919,7 @@ var runCmd = &cobra.Command{
 					KeyFile:                  cfg.KeyFile,
 					HandshakeTimeout:         cfg.HandshakeTimeout,
 					LoadbalancerStrategyName: cfg.LoadBalancer.Strategy,
+					LoadbalancerRules:        cfg.LoadBalancer.LoadBalancingRules,
 				},
 			)
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"reflect"
 	"sort"
@@ -685,11 +686,58 @@ func (c *Config) ValidateGlobalConfig(ctx context.Context) *gerr.GatewayDError {
 			err := fmt.Errorf("\"servers.%s\" is nil or empty", configGroup)
 			span.RecordError(err)
 			errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+			continue
 		}
 		if configGroup != strings.ToLower(configGroup) {
 			err := fmt.Errorf(`"servers.%s" is not lowercase`, configGroup)
 			span.RecordError(err)
 			errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+		}
+
+		// Validate Load Balancing Rules
+		if globalConfig.Servers[configGroup].LoadBalancer.LoadBalancingRules != nil {
+			for _, rule := range globalConfig.Servers[configGroup].LoadBalancer.LoadBalancingRules {
+				if rule.Condition == "" {
+					err := fmt.Errorf(`"servers.%s.loadBalancer.loadBalancingRules.condition" is nil or empty`, configGroup)
+					span.RecordError(err)
+					errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+				}
+
+				// Validate distribution list is not empty
+				if len(rule.Distribution) == 0 {
+					err := fmt.Errorf(`"servers.%s.loadBalancer.loadBalancingRules.distribution" is empty`, configGroup)
+					span.RecordError(err)
+					errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+				} else {
+					totalWeight := 0
+					for _, distribution := range rule.Distribution {
+						// Ensure proxyName exists in the configuration
+						if !clientConfigGroups[configGroup][distribution.ProxyName] {
+							err := fmt.Errorf(`"servers.%s.loadBalancer.loadBalancingRules.%s.%s" not referenced in proxy configuration`, configGroup, rule.Condition, distribution.ProxyName)
+							span.RecordError(err)
+							errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+						}
+
+						// Check if weight is positive
+						if distribution.Weight <= 0 {
+							err := fmt.Errorf(`"servers.%s.loadBalancer.loadBalancingRules.%s.%s.weight" must be positive`, configGroup, rule.Condition, distribution.ProxyName)
+							span.RecordError(err)
+							errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+						}
+
+						// Check if adding the weight causes integer overflow
+						if totalWeight > math.MaxInt-distribution.Weight {
+							err := fmt.Errorf(`"servers.%s.loadBalancer.loadBalancingRules.%s" total weight exceeds maximum int value`, configGroup, rule.Condition)
+							span.RecordError(err)
+							errors = append(errors, gerr.ErrValidationFailed.Wrap(err))
+							break
+						}
+
+						// Accumulate the weight
+						totalWeight += distribution.Weight
+					}
+				}
+			}
 		}
 	}
 

--- a/config/constants.go
+++ b/config/constants.go
@@ -90,11 +90,12 @@ const (
 	DefaultHealthCheckPeriod = 60 * time.Second // This must match PostgreSQL authentication timeout.
 
 	// Server constants.
-	DefaultListenNetwork        = "tcp"
-	DefaultListenAddress        = "0.0.0.0:15432"
-	DefaultTickInterval         = 5 * time.Second
-	DefaultHandshakeTimeout     = 5 * time.Second
-	DefaultLoadBalancerStrategy = "ROUND_ROBIN"
+	DefaultListenNetwork         = "tcp"
+	DefaultListenAddress         = "0.0.0.0:15432"
+	DefaultTickInterval          = 5 * time.Second
+	DefaultHandshakeTimeout      = 5 * time.Second
+	DefaultLoadBalancerStrategy  = "ROUND_ROBIN"
+	DefaultLoadBalancerCondition = "DEFAULT"
 
 	// Utility constants.
 	DefaultSeed = 1000
@@ -129,6 +130,7 @@ const (
 
 // Load balancing strategies.
 const (
-	RoundRobinStrategy = "ROUND_ROBIN"
-	RANDOMStrategy     = "RANDOM"
+	RoundRobinStrategy         = "ROUND_ROBIN"
+	RANDOMStrategy             = "RANDOM"
+	WeightedRoundRobinStrategy = "WEIGHTED_ROUND_ROBIN"
 )

--- a/config/types.go
+++ b/config/types.go
@@ -97,7 +97,7 @@ type Proxy struct {
 }
 
 type Distribution struct {
-	ProxyName string `json:"proxy"`
+	ProxyName string `json:"proxyName"`
 	Weight    int    `json:"weight"`
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -96,8 +96,19 @@ type Proxy struct {
 	HealthCheckPeriod time.Duration `json:"healthCheckPeriod" jsonschema:"oneof_type=string;integer" yaml:"healthCheckPeriod"`
 }
 
+type Distribution struct {
+	ProxyName string `json:"proxy"`
+	Weight    int    `json:"weight"`
+}
+
+type LoadBalancingRule struct {
+	Condition    string         `json:"condition"`
+	Distribution []Distribution `json:"distribution"`
+}
+
 type LoadBalancer struct {
-	Strategy string `json:"strategy"`
+	Strategy           string              `json:"strategy"`
+	LoadBalancingRules []LoadBalancingRule `json:"loadBalancingRules"`
 }
 
 type Server struct {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -55,6 +55,7 @@ const (
 	ErrCodePublishAsyncAction
 	ErrCodeLoadBalancerStrategyNotFound
 	ErrCodeNoProxiesAvailable
+	ErrCodeNoLoadBalancerRules
 )
 
 var (
@@ -202,6 +203,10 @@ var (
 
 	ErrNoProxiesAvailable = &GatewayDError{
 		ErrCodeNoProxiesAvailable, "No proxies available to select.", nil,
+	}
+
+	ErrNoLoadBalancerRules = &GatewayDError{
+		ErrCodeNoLoadBalancerRules, "No load balancer rules provided.", nil,
 	}
 
 	// Unwrapped errors.

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -87,9 +87,9 @@ servers:
       loadBalancingRules:
         - condition: "DEFAULT"
           distribution:
-            - proxy: "writes"
+            - proxyName: "writes"
               weight: 70
-            - proxy: "reads"
+            - proxyName: "reads"
               weight: 30
     enableTicker: False
     tickInterval: 5s # duration

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -83,7 +83,14 @@ servers:
     address: 0.0.0.0:15432
     loadBalancer:
       # Load balancer strategies can be found in config/constants.go
-      strategy: RANDOM # ROUND_ROBIN, RANDOM
+      strategy: WEIGHTED_ROUND_ROBIN # ROUND_ROBIN, RANDOM, WEIGHTED_ROUND_ROBIN
+      loadBalancingRules:
+        - condition: "DEFAULT"
+          distribution:
+            - proxy: "writes"
+              weight: 70
+            - proxy: "reads"
+              weight: 30
     enableTicker: False
     tickInterval: 5s # duration
     enableTLS: False

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -83,14 +83,15 @@ servers:
     address: 0.0.0.0:15432
     loadBalancer:
       # Load balancer strategies can be found in config/constants.go
-      strategy: WEIGHTED_ROUND_ROBIN # ROUND_ROBIN, RANDOM, WEIGHTED_ROUND_ROBIN
-      loadBalancingRules:
-        - condition: "DEFAULT"
-          distribution:
-            - proxyName: "writes"
-              weight: 70
-            - proxyName: "reads"
-              weight: 30
+      strategy: ROUND_ROBIN # ROUND_ROBIN, RANDOM, WEIGHTED_ROUND_ROBIN
+      # Optional configuration for strategies that support rules (e.g., WEIGHTED_ROUND_ROBIN)
+      # loadBalancingRules:
+      #   - condition: "DEFAULT" # Currently, only the "DEFAULT" condition is supported
+      #     distribution:
+      #       - proxyName: "writes"
+      #         weight: 70
+      #       - proxyName: "reads"
+      #         weight: 30
     enableTicker: False
     tickInterval: 5s # duration
     enableTLS: False

--- a/network/loadbalancer.go
+++ b/network/loadbalancer.go
@@ -15,7 +15,23 @@ func NewLoadBalancerStrategy(server *Server) (LoadBalancerStrategy, *gerr.Gatewa
 		return NewRoundRobin(server), nil
 	case config.RANDOMStrategy:
 		return NewRandom(server), nil
+	case config.WeightedRoundRobinStrategy:
+		if server.LoadbalancerRules == nil {
+			return nil, gerr.ErrNoLoadBalancerRules
+		}
+		loadbalancerRule := selectLoadBalancerRule(server.LoadbalancerRules)
+		return NewWeightedRoundRobin(server, loadbalancerRule), nil
 	default:
 		return nil, gerr.ErrLoadBalancerStrategyNotFound
 	}
+}
+
+func selectLoadBalancerRule(loadbalancerRules []config.LoadBalancingRule) config.LoadBalancingRule {
+	for _, loadbalancerRule := range loadbalancerRules {
+		if loadbalancerRule.Condition == config.DefaultLoadBalancerCondition {
+			return loadbalancerRule
+		}
+	}
+	// Return the first rule as a fallback
+	return loadbalancerRules[0]
 }

--- a/network/loadbalancer.go
+++ b/network/loadbalancer.go
@@ -9,6 +9,10 @@ type LoadBalancerStrategy interface {
 	NextProxy() (IProxy, *gerr.GatewayDError)
 }
 
+// NewLoadBalancerStrategy returns a LoadBalancerStrategy based on the server's load balancer strategy name.
+// If the server's load balancer strategy is weighted round-robin,
+// it selects a load balancer rule before returning the strategy.
+// Returns an error if the strategy is not found or if there are no load balancer rules when required.
 func NewLoadBalancerStrategy(server *Server) (LoadBalancerStrategy, *gerr.GatewayDError) {
 	switch server.LoadbalancerStrategyName {
 	case config.RoundRobinStrategy:
@@ -26,12 +30,14 @@ func NewLoadBalancerStrategy(server *Server) (LoadBalancerStrategy, *gerr.Gatewa
 	}
 }
 
-func selectLoadBalancerRule(loadbalancerRules []config.LoadBalancingRule) config.LoadBalancingRule {
-	for _, loadbalancerRule := range loadbalancerRules {
-		if loadbalancerRule.Condition == config.DefaultLoadBalancerCondition {
-			return loadbalancerRule
+// selectLoadBalancerRule selects and returns the first load balancer rule that matches the default condition.
+// If no rule matches, it returns the first rule in the list as a fallback.
+func selectLoadBalancerRule(rules []config.LoadBalancingRule) config.LoadBalancingRule {
+	for _, rule := range rules {
+		if rule.Condition == config.DefaultLoadBalancerCondition {
+			return rule
 		}
 	}
 	// Return the first rule as a fallback
-	return loadbalancerRules[0]
+	return rules[0]
 }

--- a/network/proxy.go
+++ b/network/proxy.go
@@ -36,9 +36,11 @@ type IProxy interface {
 	Shutdown()
 	AvailableConnectionsString() []string
 	BusyConnectionsString() []string
+	GetName() string
 }
 
 type Proxy struct {
+	Name                 string
 	AvailableConnections pool.IPool
 	busyConnections      pool.IPool
 	Logger               zerolog.Logger
@@ -134,6 +136,10 @@ func NewProxy(
 	).Msg("Started the client health check scheduler")
 
 	return &proxy
+}
+
+func (pr *Proxy) GetName() string {
+	return pr.Name
 }
 
 // Connect maps a server connection from the available connection pool to a incoming connection.

--- a/network/server.go
+++ b/network/server.go
@@ -77,6 +77,7 @@ type Server struct {
 	// loadbalancer
 	loadbalancerStrategy     LoadBalancerStrategy
 	LoadbalancerStrategyName string
+	LoadbalancerRules        []config.LoadBalancingRule
 	connectionToProxyMap     map[*ConnWrapper]IProxy
 }
 
@@ -696,6 +697,7 @@ func NewServer(
 		stopServer:               make(chan struct{}),
 		connectionToProxyMap:     make(map[*ConnWrapper]IProxy),
 		LoadbalancerStrategyName: srv.LoadbalancerStrategyName,
+		LoadbalancerRules:        srv.LoadbalancerRules,
 	}
 
 	// Try to resolve the address and log an error if it can't be resolved.

--- a/network/weightedroundrobin.go
+++ b/network/weightedroundrobin.go
@@ -1,0 +1,50 @@
+package network
+
+import (
+	"errors"
+	"sync/atomic"
+
+	"github.com/gatewayd-io/gatewayd/config"
+	gerr "github.com/gatewayd-io/gatewayd/errors"
+)
+
+type WeightedRoundRobin struct {
+	proxies []IProxy
+	next    atomic.Uint32
+}
+
+func NewWeightedRoundRobin(server *Server, loadbalancerRule config.LoadBalancingRule) *WeightedRoundRobin {
+	var proxies []IProxy
+
+	// Populate the cyclic list of proxies according to their weights.
+	for _, distribution := range loadbalancerRule.Distribution {
+		proxy := findProxyByName(distribution.ProxyName, server.Proxies)
+		if proxy != nil {
+			for i := 0; i < distribution.Weight; i++ {
+				proxies = append(proxies, proxy)
+			}
+		}
+	}
+
+	return &WeightedRoundRobin{
+		proxies: proxies,
+	}
+}
+
+func (r *WeightedRoundRobin) NextProxy() (IProxy, *gerr.GatewayDError) {
+	proxiesLen := uint32(len(r.proxies))
+	if proxiesLen == 0 {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(errors.New("proxy list is empty"))
+	}
+	nextIndex := r.next.Add(1)
+	return r.proxies[nextIndex%proxiesLen], nil
+}
+
+func findProxyByName(name string, proxies []IProxy) IProxy {
+	for _, proxy := range proxies {
+		if proxy.GetName() == name {
+			return proxy
+		}
+	}
+	return nil
+}

--- a/network/weightedroundrobin.go
+++ b/network/weightedroundrobin.go
@@ -2,44 +2,74 @@ package network
 
 import (
 	"errors"
-	"sync/atomic"
 
 	"github.com/gatewayd-io/gatewayd/config"
 	gerr "github.com/gatewayd-io/gatewayd/errors"
 )
 
+type weightedProxy struct {
+	proxy           IProxy
+	weight          int
+	currentWeight   int
+	effectiveWeight int
+}
+
 type WeightedRoundRobin struct {
-	proxies []IProxy
-	next    atomic.Uint32
+	proxies     []*weightedProxy
+	totalWeight int
 }
 
 func NewWeightedRoundRobin(server *Server, loadbalancerRule config.LoadBalancingRule) *WeightedRoundRobin {
-	var proxies []IProxy
+	var proxies []*weightedProxy
+	totalWeight := 0
 
-	// Populate the cyclic list of proxies according to their weights.
 	for _, distribution := range loadbalancerRule.Distribution {
 		proxy := findProxyByName(distribution.ProxyName, server.Proxies)
 		if proxy != nil {
-			for i := 0; i < distribution.Weight; i++ {
-				proxies = append(proxies, proxy)
-			}
+			weight := distribution.Weight
+			totalWeight += weight
+			proxies = append(proxies, &weightedProxy{
+				proxy:           proxy,
+				weight:          weight,
+				effectiveWeight: weight,
+				currentWeight:   0,
+			})
 		}
 	}
 
 	return &WeightedRoundRobin{
-		proxies: proxies,
+		proxies:     proxies,
+		totalWeight: totalWeight,
 	}
 }
 
+// NextProxy selects the next proxy based on the weighted round-robin algorithm.
 func (r *WeightedRoundRobin) NextProxy() (IProxy, *gerr.GatewayDError) {
-	proxiesLen := uint32(len(r.proxies))
-	if proxiesLen == 0 {
+
+	if len(r.proxies) == 0 {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(errors.New("proxy list is empty"))
 	}
-	nextIndex := r.next.Add(1)
-	return r.proxies[nextIndex%proxiesLen], nil
+
+	var selected *weightedProxy
+
+	// Adjust weights and select the proxy with the highest current weight.
+	for _, p := range r.proxies {
+		p.currentWeight += p.effectiveWeight
+		if selected == nil || p.currentWeight > selected.currentWeight {
+			selected = p
+		}
+	}
+
+	// Reduce the selected proxy's current weight by the total weight.
+	if selected != nil {
+		selected.currentWeight -= r.totalWeight
+		return selected.proxy, nil
+	}
+
+	return nil, gerr.ErrNoProxiesAvailable.Wrap(errors.New("no proxy selected"))
 }
 
+// findProxyByName finds a proxy by name from the list of proxies.
 func findProxyByName(name string, proxies []IProxy) IProxy {
 	for _, proxy := range proxies {
 		if proxy.GetName() == name {

--- a/network/weightedroundrobin_test.go
+++ b/network/weightedroundrobin_test.go
@@ -1,0 +1,170 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/gatewayd-io/gatewayd/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWeightedRoundRobin(t *testing.T) {
+	proxies := []IProxy{
+		MockProxy{name: "proxy1"},
+		MockProxy{name: "proxy2"},
+		MockProxy{name: "proxy3"},
+	}
+
+	t.Run("loadBalancingRule with all proxies", func(t *testing.T) {
+		loadBalancingRule := config.LoadBalancingRule{
+			Condition: config.DefaultLoadBalancerCondition,
+			Distribution: []config.Distribution{
+				{
+					ProxyName: "proxy1",
+					Weight:    40,
+				},
+				{
+					ProxyName: "proxy2",
+					Weight:    60,
+				},
+				{
+					ProxyName: "proxy3",
+					Weight:    30,
+				},
+			},
+		}
+		server := &Server{Proxies: proxies}
+		weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+		assert.NotNil(t, weightedRR, "weightedRR should not be nil")
+		assert.Equal(t, len(loadBalancingRule.Distribution), len(weightedRR.proxies), "proxies count mismatch")
+	})
+
+	t.Run("loadBalancingRule with a subset of proxies", func(t *testing.T) {
+		loadBalancingRule := config.LoadBalancingRule{
+			Condition: config.DefaultLoadBalancerCondition,
+			Distribution: []config.Distribution{
+				{
+					ProxyName: "proxy1",
+					Weight:    40,
+				},
+				{
+					ProxyName: "proxy2",
+					Weight:    60,
+				},
+			},
+		}
+		server := &Server{Proxies: proxies}
+		weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+		assert.NotNil(t, weightedRR, "weightedRR should not be nil")
+		assert.Equal(t, len(loadBalancingRule.Distribution), len(weightedRR.proxies), "proxies count mismatch")
+	})
+
+	t.Run("loadBalancingRule with missing proxy", func(t *testing.T) {
+		loadBalancingRule := config.LoadBalancingRule{
+			Condition: config.DefaultLoadBalancerCondition,
+			Distribution: []config.Distribution{
+				{
+					ProxyName: "proxy1",
+					Weight:    50,
+				},
+				{
+					ProxyName: "missing_proxy",
+					Weight:    50,
+				},
+			},
+		}
+		server := &Server{Proxies: proxies}
+		weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+		assert.NotNil(t, weightedRR, "weightedRR should not be nil")
+		assert.Equal(t, 1, len(weightedRR.proxies), "should ignore missing proxies and only include available ones")
+	})
+
+	t.Run("loadBalancingRule with empty distribution", func(t *testing.T) {
+		loadBalancingRule := config.LoadBalancingRule{
+			Condition:    config.DefaultLoadBalancerCondition,
+			Distribution: []config.Distribution{}, // empty distribution
+		}
+		server := &Server{Proxies: proxies}
+		weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+		assert.NotNil(t, weightedRR, "weightedRR should not be nil")
+		assert.Equal(t, 0, len(weightedRR.proxies), "no proxies should be included")
+	})
+
+	t.Run("loadBalancingRule with nil distribution", func(t *testing.T) {
+		loadBalancingRule := config.LoadBalancingRule{
+			Condition:    config.DefaultLoadBalancerCondition,
+			Distribution: nil, // nil distribution
+		}
+		server := &Server{Proxies: proxies}
+		weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+		assert.NotNil(t, weightedRR, "weightedRR should not be nil")
+		assert.Equal(t, 0, len(weightedRR.proxies), "no proxies should be included")
+	})
+}
+
+func TestWeightedRoundRobinNextProxy(t *testing.T) {
+	proxies := []IProxy{
+		MockProxy{name: "proxy1"},
+		MockProxy{name: "proxy2"},
+		MockProxy{name: "proxy3"},
+	}
+	loadBalancingRule := config.LoadBalancingRule{
+		Condition: config.DefaultLoadBalancerCondition,
+		Distribution: []config.Distribution{
+			{
+				ProxyName: "proxy1",
+				Weight:    30,
+			},
+			{
+				ProxyName: "proxy2",
+				Weight:    60,
+			},
+			{
+				ProxyName: "proxy3",
+				Weight:    10,
+			},
+		},
+	}
+	server := &Server{Proxies: proxies}
+	weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
+
+	// Define the expected distribution percentages.
+	expectedWeights := map[string]int{
+		"proxy1": 30,
+		"proxy2": 60,
+		"proxy3": 10,
+	}
+
+	// Total number of iterations to simulate
+	totalRequests := 1000
+	counts := map[string]int{
+		"proxy1": 0,
+		"proxy2": 0,
+		"proxy3": 0,
+	}
+
+	for i := 0; i < totalRequests; i++ {
+		proxy, err := weightedRR.NextProxy()
+		require.Nil(t, err)
+
+		mockProxy, ok := proxy.(MockProxy)
+		require.True(t, ok, "expected proxy of type MockProxy, got %T", proxy)
+
+		counts[mockProxy.GetName()]++
+	}
+
+	// Check that the distribution is within an acceptable range
+	for proxyName, expectedWeight := range expectedWeights {
+		expectedCount := totalRequests * expectedWeight / 100
+		actualCount := counts[proxyName]
+
+		// Allow a small margin of error
+		assert.InDeltaf(t, expectedCount, actualCount, 5,
+			"proxy %s: expected approximately %d, but got %d", proxyName, expectedCount, actualCount)
+	}
+}

--- a/network/weightedroundrobin_test.go
+++ b/network/weightedroundrobin_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestNewWeightedRoundRobin tests the creation and initialization of the
+// NewWeightedRoundRobin function with various load balancing rules.
 func TestNewWeightedRoundRobin(t *testing.T) {
 	proxies := []IProxy{
 		MockProxy{name: "proxy1"},
@@ -16,22 +18,14 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 		MockProxy{name: "proxy3"},
 	}
 
+	// Test with a load balancing rule that includes all proxies.
 	t.Run("loadBalancingRule with all proxies", func(t *testing.T) {
 		loadBalancingRule := config.LoadBalancingRule{
 			Condition: config.DefaultLoadBalancerCondition,
 			Distribution: []config.Distribution{
-				{
-					ProxyName: "proxy1",
-					Weight:    40,
-				},
-				{
-					ProxyName: "proxy2",
-					Weight:    60,
-				},
-				{
-					ProxyName: "proxy3",
-					Weight:    30,
-				},
+				{ProxyName: "proxy1", Weight: 40},
+				{ProxyName: "proxy2", Weight: 60},
+				{ProxyName: "proxy3", Weight: 30},
 			},
 		}
 		server := &Server{Proxies: proxies}
@@ -41,18 +35,13 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 		assert.Equal(t, len(loadBalancingRule.Distribution), len(weightedRR.proxies), "proxies count mismatch")
 	})
 
+	// Test with a load balancing rule that includes a subset of proxies.
 	t.Run("loadBalancingRule with a subset of proxies", func(t *testing.T) {
 		loadBalancingRule := config.LoadBalancingRule{
 			Condition: config.DefaultLoadBalancerCondition,
 			Distribution: []config.Distribution{
-				{
-					ProxyName: "proxy1",
-					Weight:    40,
-				},
-				{
-					ProxyName: "proxy2",
-					Weight:    60,
-				},
+				{ProxyName: "proxy1", Weight: 40},
+				{ProxyName: "proxy2", Weight: 60},
 			},
 		}
 		server := &Server{Proxies: proxies}
@@ -62,18 +51,13 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 		assert.Equal(t, len(loadBalancingRule.Distribution), len(weightedRR.proxies), "proxies count mismatch")
 	})
 
+	// Test with a load balancing rule that references a missing proxy.
 	t.Run("loadBalancingRule with missing proxy", func(t *testing.T) {
 		loadBalancingRule := config.LoadBalancingRule{
 			Condition: config.DefaultLoadBalancerCondition,
 			Distribution: []config.Distribution{
-				{
-					ProxyName: "proxy1",
-					Weight:    50,
-				},
-				{
-					ProxyName: "missing_proxy",
-					Weight:    50,
-				},
+				{ProxyName: "proxy1", Weight: 50},
+				{ProxyName: "missing_proxy", Weight: 50},
 			},
 		}
 		server := &Server{Proxies: proxies}
@@ -83,6 +67,7 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 		assert.Equal(t, 1, len(weightedRR.proxies), "should ignore missing proxies and only include available ones")
 	})
 
+	// Test with an empty distribution list in the load balancing rule.
 	t.Run("loadBalancingRule with empty distribution", func(t *testing.T) {
 		loadBalancingRule := config.LoadBalancingRule{
 			Condition:    config.DefaultLoadBalancerCondition,
@@ -95,6 +80,7 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 		assert.Equal(t, 0, len(weightedRR.proxies), "no proxies should be included")
 	})
 
+	// Test with a nil distribution list in the load balancing rule.
 	t.Run("loadBalancingRule with nil distribution", func(t *testing.T) {
 		loadBalancingRule := config.LoadBalancingRule{
 			Condition:    config.DefaultLoadBalancerCondition,
@@ -108,40 +94,35 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 	})
 }
 
+// TestWeightedRoundRobinNextProxy verifies that the WeightedRoundRobin algorithm
+// correctly distributes requests among proxies according to their weights.
 func TestWeightedRoundRobinNextProxy(t *testing.T) {
 	proxies := []IProxy{
 		MockProxy{name: "proxy1"},
 		MockProxy{name: "proxy2"},
 		MockProxy{name: "proxy3"},
 	}
+
 	loadBalancingRule := config.LoadBalancingRule{
 		Condition: config.DefaultLoadBalancerCondition,
 		Distribution: []config.Distribution{
-			{
-				ProxyName: "proxy1",
-				Weight:    30,
-			},
-			{
-				ProxyName: "proxy2",
-				Weight:    60,
-			},
-			{
-				ProxyName: "proxy3",
-				Weight:    10,
-			},
+			{ProxyName: "proxy1", Weight: 30},
+			{ProxyName: "proxy2", Weight: 60},
+			{ProxyName: "proxy3", Weight: 10},
 		},
 	}
+
 	server := &Server{Proxies: proxies}
 	weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
 
-	// Define the expected distribution percentages.
+	// Expected distribution of requests among proxies based on the weights.
 	expectedWeights := map[string]int{
 		"proxy1": 30,
 		"proxy2": 60,
 		"proxy3": 10,
 	}
 
-	// Total number of iterations to simulate
+	// Total number of simulated requests to distribute among proxies.
 	totalRequests := 1000
 	counts := map[string]int{
 		"proxy1": 0,
@@ -149,7 +130,8 @@ func TestWeightedRoundRobinNextProxy(t *testing.T) {
 		"proxy3": 0,
 	}
 
-	for i := 0; i < totalRequests; i++ {
+	// Simulate the distribution of requests using the WeightedRoundRobin algorithm.
+	for range totalRequests {
 		proxy, err := weightedRR.NextProxy()
 		require.Nil(t, err)
 
@@ -159,57 +141,55 @@ func TestWeightedRoundRobinNextProxy(t *testing.T) {
 		counts[mockProxy.GetName()]++
 	}
 
-	// Check that the distribution is within an acceptable range
+	// Validate that the actual distribution of requests closely matches the expected distribution.
 	for proxyName, expectedWeight := range expectedWeights {
 		expectedCount := totalRequests * expectedWeight / 100
 		actualCount := counts[proxyName]
 
-		// Allow a small margin of error
+		// Allow a small margin of error (delta of 5) in the actual count.
 		assert.InDeltaf(t, expectedCount, actualCount, 5,
 			"proxy %s: expected approximately %d, but got %d", proxyName, expectedCount, actualCount)
 	}
 }
 
+// TestWeightedRoundRobinConcurrentAccess tests the thread-safety of the
+// WeightedRoundRobin algorithm by simulating concurrent access through
+// multiple goroutines and ensuring the expected proxy distribution.
 func TestWeightedRoundRobinConcurrentAccess(t *testing.T) {
 	proxies := []IProxy{
 		MockProxy{name: "proxy1"},
 		MockProxy{name: "proxy2"},
 		MockProxy{name: "proxy3"},
 	}
+
 	loadBalancingRule := config.LoadBalancingRule{
 		Condition: config.DefaultLoadBalancerCondition,
 		Distribution: []config.Distribution{
-			{
-				ProxyName: "proxy1",
-				Weight:    3,
-			},
-			{
-				ProxyName: "proxy2",
-				Weight:    2,
-			},
-			{
-				ProxyName: "proxy3",
-				Weight:    1,
-			},
+			{ProxyName: "proxy1", Weight: 3},
+			{ProxyName: "proxy2", Weight: 2},
+			{ProxyName: "proxy3", Weight: 1},
 		},
 	}
+
 	server := &Server{Proxies: proxies}
 	weightedRR := NewWeightedRoundRobin(server, loadBalancingRule)
 
-	// Use a wait group to wait for all goroutines to finish
-	var wg sync.WaitGroup
+	// WaitGroup to synchronize the completion of all goroutines.
+	var waitGroup sync.WaitGroup
 	numGoroutines := 100
 	proxySelection := make(map[string]int)
 	var mux sync.Mutex
 
-	// Run multiple goroutines to simulate concurrent access
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
+	// Run multiple goroutines to simulate concurrent access to the NextProxy method.
+	for range numGoroutines {
+		waitGroup.Add(1)
 		go func() {
-			defer wg.Done()
+			defer waitGroup.Done()
 
+			// Retrieve the next proxy using the WeightedRoundRobin algorithm.
 			proxy, err := weightedRR.NextProxy()
 			if assert.Nil(t, err, "No error expected when getting a proxy") {
+				// Safely update the proxy selection count using a mutex.
 				mux.Lock()
 				proxySelection[proxy.GetName()]++
 				mux.Unlock()
@@ -217,16 +197,17 @@ func TestWeightedRoundRobinConcurrentAccess(t *testing.T) {
 		}()
 	}
 
-	// Wait for all goroutines to complete
-	wg.Wait()
+	// Wait for all goroutines to finish.
+	waitGroup.Wait()
 
-	// Verify that the proxies were selected as expected
+	// Expected number of selections for each proxy based on their weights.
 	expectedSelections := map[string]int{
 		"proxy1": 50, // proxy1 should be selected 50 times (3/6 of 100)
 		"proxy2": 33, // proxy2 should be selected 33 times (2/6 of 100)
 		"proxy3": 17, // proxy3 should be selected 17 times (1/6 of 100)
 	}
 
+	// Validate that the actual selection counts are close to the expected counts.
 	for name, expectedCount := range expectedSelections {
 		actualCount, exists := proxySelection[name]
 		assert.True(t, exists, "Expected proxy %s to be selected", name)


### PR DESCRIPTION
# Ticket(s)
https://github.com/gatewayd-io/gatewayd/issues/398
## Description
This PR introduces a new load balancing strategy, `Weighted Round Robin`, to the existing load balancer module. The changes include:

### Implementation of Weighted Round Robin:

A new algorithm WeightedRoundRobin is introduced which selects proxies based on predefined weights.
The weights are configured via the LoadBalancingRules in the server's configuration.
Each proxy's selection frequency corresponds to its assigned weight, ensuring a proportional distribution of traffic.

### Configuration Changes:

Updated config/types.go to include LoadBalancingRule and Distribution structures to support the new load balancing strategy.
Modified config/constants.go to add WeightedRoundRobinStrategy as a valid load balancing strategy.
Updated gatewayd.yaml to provide an example configuration for the WEIGHTED_ROUND_ROBIN strategy.
Validation:

Added validation logic in config/config.go to ensure load balancing rules are correctly defined and weights are positive.
Extended error handling in errors/errors.go to account for scenarios where no load balancing rules are provided for weighted round robin.

### Unit Tests:

Created comprehensive tests in network/weightedroundrobin_test.go to verify the correct behavior of the WeightedRoundRobin implementation under various scenarios, including empty and missing proxies.

## Related PRs

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
