### PR TITLE
Fix Consistent Hashing to Use Remote Address Instead of Local Address

### DIFF
--- a/network/consistenthash_test.go
+++ b/network/consistenthash_test.go
@@ -42,9 +42,9 @@ func TestConsistentHashNextProxyUseSourceIpExists(t *testing.T) {
 	consistentHash := NewConsistentHash(server, originalStrategy)
 	mockConn := new(MockConnWrapper)
 
-	// Mock LocalAddr to return a specific IP:port format
+	// Mock RemoteAddr to return a specific IP:port format
 	mockAddr := &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}
-	mockConn.On("LocalAddr").Return(mockAddr)
+	mockConn.On("RemoteAddr").Return(mockAddr)
 
 	key := "192.168.1.1"
 	hash := hashKey(key)
@@ -77,9 +77,9 @@ func TestConsistentHashNextProxyUseFullAddress(t *testing.T) {
 	}
 	mockStrategy := NewRoundRobin(server)
 
-	// Mock LocalAddr to return full address
+	// Mock RemoteAddr to return full address
 	mockAddr := &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}
-	mockConn.On("LocalAddr").Return(mockAddr)
+	mockConn.On("RemoteAddr").Return(mockAddr)
 
 	consistentHash := NewConsistentHash(server, mockStrategy)
 
@@ -120,8 +120,8 @@ func TestConsistentHashNextProxyConcurrency(t *testing.T) {
 	// Mock IP addresses
 	mockAddr1 := &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 1234}
 	mockAddr2 := &net.TCPAddr{IP: net.ParseIP("192.168.1.2"), Port: 1234}
-	conn1.On("LocalAddr").Return(mockAddr1)
-	conn2.On("LocalAddr").Return(mockAddr2)
+	conn1.On("RemoteAddr").Return(mockAddr1)
+	conn2.On("RemoteAddr").Return(mockAddr2)
 
 	// Initialize the ConsistentHash
 	consistentHash := NewConsistentHash(server, originalStrategy)


### PR DESCRIPTION
## Description
This PR updates the consistent hashing logic to use the remote address (RemoteAddr) of a connection instead of the local address (LocalAddr). The change addresses the following issues:

1. When a new connection is opened, LocalAddr points to the gateway address, while RemoteAddr correctly points to the client’s source IP. The previous use of LocalAddr caused issues, such as always directing traffic to the same database.
2. The fallback behavior now utilizes the full remote address (IP:port) as the key when `useSourceIP` is set to `false`. This change fixes the issue where the useSourceIP is disabled, as the remote address has a random port each time, making the key different.

Additionally, this PR:

- Updates comments to clarify the changes in hashing logic.
- Modifies test cases in consistenthash_test.go to mock RemoteAddr instead of LocalAddr and ensure the correct behavior is tested.


## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
