### PR TITLE
Fix bug in handling postgres `COPY` command and a few others

### DIFF
--- a/network/client.go
+++ b/network/client.go
@@ -231,7 +231,7 @@ func (c *Client) Receive() (int, []byte, *gerr.GatewayDError) {
 		ctx = context.Background()
 	}
 
-	var received int
+	total := 0
 	buffer := bytes.NewBuffer(nil)
 	// Read the data in chunks.
 	for ctx.Err() == nil {
@@ -240,19 +240,19 @@ func (c *Client) Receive() (int, []byte, *gerr.GatewayDError) {
 		if err != nil {
 			c.logger.Error().Err(err).Msg("Couldn't receive data from the server")
 			span.RecordError(err)
-			return received, buffer.Bytes(), gerr.ErrClientReceiveFailed.Wrap(err)
+			return total, buffer.Bytes(), gerr.ErrClientReceiveFailed.Wrap(err)
 		}
-		received += read
+		total += read
 		buffer.Write(chunk[:read])
 
-		if read == 0 || read < c.ReceiveChunkSize {
+		if total == 0 || read < c.ReceiveChunkSize {
 			break
 		}
 	}
 
 	span.AddEvent("Received data from server")
 
-	return received, buffer.Bytes(), nil
+	return total, buffer.Bytes(), nil
 }
 
 // Reconnect reconnects to the server.

--- a/network/client.go
+++ b/network/client.go
@@ -245,7 +245,7 @@ func (c *Client) Receive() (int, []byte, *gerr.GatewayDError) {
 		total += read
 		buffer.Write(chunk[:read])
 
-		if total == 0 || read < c.ReceiveChunkSize {
+		if read < c.ReceiveChunkSize {
 			break
 		}
 	}

--- a/network/proxy.go
+++ b/network/proxy.go
@@ -721,7 +721,7 @@ func (pr *Proxy) receiveTrafficFromClient(conn net.Conn) ([]byte, *gerr.GatewayD
 		total += read
 		buffer.Write(chunk[:read])
 
-		if total == 0 || read < pr.ClientConfig.ReceiveChunkSize {
+		if read < pr.ClientConfig.ReceiveChunkSize {
 			break
 		}
 


### PR DESCRIPTION
# Ticket(s)

Closes #533.

## Description

After hours of debugging, I discovered that the issue stemmed from a few incorrect assumptions. The first was that the chunk size read from the connection should be compared to the `ReceiveChunkSize`, rather than the total amount of data received up to that point. The second assumption was that receiving zero data from the server should automatically close the connection, which has since been resolved.

The third assumption was that every request to PostgreSQL would elicit an immediate response, but the behavior of the [`COPY` command](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY) proved otherwise. When a client issues a `COPY` command to the server, PostgreSQL replies with a `CopyInResponse`. If no errors occur, the client begins sending `CopyData` messages, which may consist of multiple requests, depending on the chunk size. After each `CopyData` message, however, the server does not send an acknowledgment or response—it simply waits. Only when the client sends a `CopyDone` message at the end of the data transmission does the server reply with `CommandComplete` and `ReadyForQuery` messages. This means the client can send multiple requests without receiving an immediate response for each one. The final `ReadyForQuery` response from the server signals that the client can proceed with the next request.

Ref: https://www.postgresql.org/docs/current/protocol-message-formats.html

In order to make sure that it works as expected, I tested the referenced SQL dump file in the issue and it works like a charm. I tested GatewayD with `pgbench` and found out that concurrent reads and writes to the `Server.connectionToProxyMap` causes fatal errors, hence exiting the process. I changed the type to `sync.Map` to avoid this in the future and make GatewayD more stable. Note that the `tps` before and after the change is decreased and the latency is increased, which is expected:

**Before:**
```bash
PGPASSWORD=postgres pgbench -M extended --transactions 100 --jobs 10 --client 99 -h localhost -p 15432 -U postgres postgres
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: extended
number of clients: 99
number of threads: 10
number of transactions per client: 100
number of transactions actually processed: 9900/9900
latency average = 188.036 ms
tps = 526.495434 (including connections establishing)
tps = 527.065595 (excluding connections establishing)
```

**After:**
```bash
PGPASSWORD=postgres pgbench -M extended --transactions 100 --jobs 10 --client 99 -h localhost -p 15432 -U postgres postgres
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: extended
number of clients: 99
number of threads: 10
number of transactions per client: 100
number of transactions actually processed: 9900/9900
latency average = 197.091 ms
tps = 502.307211 (including connections establishing)
tps = 502.959156 (excluding connections establishing)
```

CC @sh-soltanpour

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
