### PR TITLE
Add metric labels

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -696,6 +696,8 @@ var runCmd = &cobra.Command{
 				// Add clients to the pool.
 				for range currentPoolSize {
 					clientConfig := clients[configGroupName][configBlockName]
+					clientConfig.GroupName = configGroupName
+					clientConfig.BlockName = configBlockName
 					client := network.NewClient(
 						runCtx, clientConfig, logger,
 						network.NewRetry(
@@ -716,6 +718,7 @@ var runCmd = &cobra.Command{
 					if client != nil {
 						eventOptions := trace.WithAttributes(
 							attribute.String("name", configBlockName),
+							attribute.String("group", configGroupName),
 							attribute.String("network", client.Network),
 							attribute.String("address", client.Address),
 							attribute.Int("receiveChunkSize", client.ReceiveChunkSize),
@@ -746,6 +749,8 @@ var runCmd = &cobra.Command{
 
 						clientCfg := map[string]interface{}{
 							"id":                 client.ID,
+							"name":               configBlockName,
+							"group":              configGroupName,
 							"network":            client.Network,
 							"address":            client.Address,
 							"receiveChunkSize":   client.ReceiveChunkSize,
@@ -851,7 +856,8 @@ var runCmd = &cobra.Command{
 				proxies[configGroupName][configBlockName] = network.NewProxy(
 					runCtx,
 					network.Proxy{
-						Name:                 configBlockName,
+						GroupName:            configGroupName,
+						BlockName:            configBlockName,
 						AvailableConnections: pools[configGroupName][configBlockName],
 						PluginRegistry:       pluginRegistry,
 						HealthCheckPeriod:    cfg.HealthCheckPeriod,
@@ -899,8 +905,9 @@ var runCmd = &cobra.Command{
 			servers[name] = network.NewServer(
 				runCtx,
 				network.Server{
-					Network: cfg.Network,
-					Address: cfg.Address,
+					GroupName: name,
+					Network:   cfg.Network,
+					Address:   cfg.Address,
 					TickInterval: config.If(
 						cfg.TickInterval > 0,
 						cfg.TickInterval,

--- a/config/types.go
+++ b/config/types.go
@@ -44,6 +44,9 @@ type ActionRedisConfig struct {
 }
 
 type Client struct {
+	BlockName string `json:"-"`
+	GroupName string `json:"-"`
+
 	Network            string        `json:"network" jsonschema:"enum=tcp,enum=udp,enum=unix" yaml:"network"`
 	Address            string        `json:"address" yaml:"address"`
 	TCPKeepAlive       bool          `json:"tcpKeepAlive" yaml:"tcpKeepAlive"`

--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -85,7 +85,7 @@ servers:
       # Load balancer strategies can be found in config/constants.go
       strategy: ROUND_ROBIN # ROUND_ROBIN, RANDOM, WEIGHTED_ROUND_ROBIN
       consistentHash:
-        useSourceIp: true
+        useSourceIp: true # Set to false for using the RANDOM strategy
       # Optional configuration for strategies that support rules (e.g., WEIGHTED_ROUND_ROBIN)
       # loadBalancingRules:
       #   - condition: "DEFAULT" # Currently, only the "DEFAULT" condition is supported

--- a/metrics/builtins.go
+++ b/metrics/builtins.go
@@ -10,51 +10,51 @@ const (
 )
 
 var (
-	ClientConnections = promauto.NewGauge(prometheus.GaugeOpts{
+	ClientConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "client_connections",
 		Help:      "Number of client connections",
-	})
-	ServerConnections = promauto.NewGauge(prometheus.GaugeOpts{
+	}, []string{"group", "block"})
+	ServerConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "server_connections",
 		Help:      "Number of server connections",
-	})
-	TLSConnections = promauto.NewGauge(prometheus.GaugeOpts{
+	}, []string{"group", "block"})
+	TLSConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "tls_connections",
 		Help:      "Number of TLS connections",
-	})
+	}, []string{"group", "block"})
 	ServerTicksFired = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "server_ticks_fired_total",
 		Help:      "Total number of server ticks fired",
 	})
-	BytesReceivedFromClient = promauto.NewSummary(prometheus.SummaryOpts{
+	BytesReceivedFromClient = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "bytes_received_from_client",
 		Help:      "Number of bytes received from client",
-	})
-	BytesSentToServer = promauto.NewSummary(prometheus.SummaryOpts{
+	}, []string{"group", "block"})
+	BytesSentToServer = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "bytes_sent_to_server",
 		Help:      "Number of bytes sent to server",
-	})
-	BytesReceivedFromServer = promauto.NewSummary(prometheus.SummaryOpts{
+	}, []string{"group", "block"})
+	BytesReceivedFromServer = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "bytes_received_from_server",
 		Help:      "Number of bytes received from server",
-	})
-	BytesSentToClient = promauto.NewSummary(prometheus.SummaryOpts{
+	}, []string{"group", "block"})
+	BytesSentToClient = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "bytes_sent_to_client",
 		Help:      "Number of bytes sent to client",
-	})
-	TotalTrafficBytes = promauto.NewSummary(prometheus.SummaryOpts{
+	}, []string{"group", "block"})
+	TotalTrafficBytes = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "traffic_bytes",
 		Help:      "Number of total bytes passed through GatewayD via client or server",
-	})
+	}, []string{"group", "block"})
 	PluginsLoaded = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "plugins_loaded_total",
@@ -70,31 +70,31 @@ var (
 		Name:      "plugin_hooks_executed_total",
 		Help:      "Number of plugin hooks executed",
 	})
-	ProxyHealthChecks = promauto.NewCounter(prometheus.CounterOpts{
+	ProxyHealthChecks = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "proxy_health_checks_total",
 		Help:      "Number of proxy health checks",
-	})
-	ProxiedConnections = promauto.NewGauge(prometheus.GaugeOpts{
+	}, []string{"group", "block"})
+	ProxiedConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "proxied_connections",
 		Help:      "Number of proxy connects",
-	})
-	ProxyPassThroughsToClient = promauto.NewCounter(prometheus.CounterOpts{
+	}, []string{"group", "block"})
+	ProxyPassThroughsToClient = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "proxy_passthroughs_to_client_total",
 		Help:      "Number of successful proxy passthroughs from server to client",
-	})
-	ProxyPassThroughsToServer = promauto.NewCounter(prometheus.CounterOpts{
+	}, []string{"group", "block"})
+	ProxyPassThroughsToServer = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "proxy_passthroughs_to_server_total",
 		Help:      "Number of successful proxy passthroughs from client to server",
-	})
-	ProxyPassThroughTerminations = promauto.NewCounter(prometheus.CounterOpts{
+	}, []string{"group", "block"})
+	ProxyPassThroughTerminations = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "proxy_passthrough_terminations_total",
 		Help:      "Number of proxy passthrough terminations by plugins",
-	})
+	}, []string{"group", "block"})
 	APIRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "api_requests_total",

--- a/network/client.go
+++ b/network/client.go
@@ -35,6 +35,9 @@ type Client struct {
 	mu        sync.Mutex
 	retry     IRetry
 
+	GroupName string
+	BlockName string
+
 	TCPKeepAlive       bool
 	TCPKeepAlivePeriod time.Duration
 	ReceiveChunkSize   int
@@ -168,7 +171,7 @@ func NewClient(
 		logger,
 	)
 
-	metrics.ServerConnections.Inc()
+	metrics.ServerConnections.WithLabelValues(clientConfig.GroupName, clientConfig.BlockName).Inc()
 
 	return &client
 }
@@ -267,7 +270,7 @@ func (c *Client) Reconnect() error {
 	if c.conn != nil {
 		c.Close()
 	} else {
-		metrics.ServerConnections.Dec()
+		metrics.ServerConnections.WithLabelValues(c.GroupName, c.BlockName).Dec()
 	}
 	c.connected.Store(false)
 
@@ -306,7 +309,7 @@ func (c *Client) Reconnect() error {
 	)
 	c.connected.Store(true)
 	c.logger.Debug().Str("address", c.Address).Msg("Reconnected to server")
-	metrics.ServerConnections.Inc()
+	metrics.ServerConnections.WithLabelValues(c.GroupName, c.BlockName).Inc()
 	span.AddEvent("Reconnected to server")
 
 	return nil
@@ -343,7 +346,7 @@ func (c *Client) Close() {
 	c.Address = ""
 	c.Network = ""
 
-	metrics.ServerConnections.Dec()
+	metrics.ServerConnections.WithLabelValues(c.GroupName, c.BlockName).Dec()
 
 	span.AddEvent("Closed connection to server")
 }

--- a/network/network_helpers_test.go
+++ b/network/network_helpers_test.go
@@ -295,6 +295,10 @@ func (m MockProxy) GetBlockName() string {
 	return m.name
 }
 
+func (m MockProxy) GetGroupName() string {
+	return "default"
+}
+
 // Mock implementation of IConnWrapper.
 type MockConnWrapper struct {
 	mock.Mock

--- a/network/network_helpers_test.go
+++ b/network/network_helpers_test.go
@@ -290,8 +290,8 @@ func (m MockProxy) BusyConnectionsString() []string {
 	return nil
 }
 
-// GetName returns the name of the MockProxy.
-func (m MockProxy) GetName() string {
+// GetBlockName returns the name of the MockProxy.
+func (m MockProxy) GetBlockName() string {
 	return m.name
 }
 

--- a/network/proxy.go
+++ b/network/proxy.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+//nolint:interfacebloat
 type IProxy interface {
 	Connect(conn *ConnWrapper) *gerr.GatewayDError
 	Disconnect(conn *ConnWrapper) *gerr.GatewayDError

--- a/network/proxy.go
+++ b/network/proxy.go
@@ -36,11 +36,13 @@ type IProxy interface {
 	Shutdown()
 	AvailableConnectionsString() []string
 	BusyConnectionsString() []string
-	GetName() string
+	GetGroupName() string
+	GetBlockName() string
 }
 
 type Proxy struct {
-	Name                 string
+	GroupName            string
+	BlockName            string
 	AvailableConnections pool.IPool
 	busyConnections      pool.IPool
 	Logger               zerolog.Logger
@@ -65,6 +67,8 @@ func NewProxy(
 	defer span.End()
 
 	proxy := Proxy{
+		GroupName:            pxy.GroupName,
+		BlockName:            pxy.BlockName,
 		AvailableConnections: pxy.AvailableConnections,
 		busyConnections:      pool.NewPool(proxyCtx, config.EmptyPoolCapacity),
 		Logger:               pxy.Logger,
@@ -118,7 +122,8 @@ func NewProxy(
 			})
 			proxy.Logger.Trace().Str("duration", time.Since(now).String()).Msg(
 				"Finished the client health check")
-			metrics.ProxyHealthChecks.Inc()
+			metrics.ProxyHealthChecks.WithLabelValues(
+				proxy.GetGroupName(), proxy.GetBlockName()).Inc()
 		},
 	); err != nil {
 		proxy.Logger.Error().Err(err).Msg("Failed to schedule the client health check")
@@ -138,8 +143,12 @@ func NewProxy(
 	return &proxy
 }
 
-func (pr *Proxy) GetName() string {
-	return pr.Name
+func (pr *Proxy) GetBlockName() string {
+	return pr.BlockName
+}
+
+func (pr *Proxy) GetGroupName() string {
+	return pr.GroupName
 }
 
 // Connect maps a server connection from the available connection pool to a incoming connection.
@@ -181,7 +190,7 @@ func (pr *Proxy) Connect(conn *ConnWrapper) *gerr.GatewayDError {
 		return err
 	}
 
-	metrics.ProxiedConnections.Inc()
+	metrics.ProxiedConnections.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
 
 	fields := map[string]interface{}{
 		"function": "proxy.connect",
@@ -244,7 +253,7 @@ func (pr *Proxy) Disconnect(conn *ConnWrapper) *gerr.GatewayDError {
 		return gerr.ErrCastFailed
 	}
 
-	metrics.ProxiedConnections.Dec()
+	metrics.ProxiedConnections.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Dec()
 
 	pr.Logger.Debug().Fields(
 		map[string]interface{}{
@@ -354,7 +363,7 @@ func (pr *Proxy) PassThroughToServer(conn *ConnWrapper, stack *Stack) *gerr.Gate
 				},
 			).Msg("Performed the TLS handshake")
 			span.AddEvent("Performed the TLS handshake")
-			metrics.TLSConnections.Inc()
+			metrics.TLSConnections.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
 		} else {
 			pr.Logger.Error().Fields(
 				map[string]interface{}{
@@ -410,10 +419,10 @@ func (pr *Proxy) PassThroughToServer(conn *ConnWrapper, stack *Stack) *gerr.Gate
 		}
 
 		if modResponse, modReceived := pr.getPluginModifiedResponse(result); modResponse != nil {
-			metrics.ProxyPassThroughsToClient.Inc()
-			metrics.ProxyPassThroughTerminations.Inc()
-			metrics.BytesSentToClient.Observe(float64(modReceived))
-			metrics.TotalTrafficBytes.Observe(float64(modReceived))
+			metrics.ProxyPassThroughsToClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
+			metrics.ProxyPassThroughTerminations.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
+			metrics.BytesSentToClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(modReceived))
+			metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(modReceived))
 
 			span.AddEvent("Terminating connection")
 
@@ -460,7 +469,7 @@ func (pr *Proxy) PassThroughToServer(conn *ConnWrapper, stack *Stack) *gerr.Gate
 	}
 	span.AddEvent("Ran the OnTrafficToServer hooks")
 
-	metrics.ProxyPassThroughsToServer.Inc()
+	metrics.ProxyPassThroughsToServer.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
 
 	return nil
 }
@@ -597,7 +606,7 @@ func (pr *Proxy) PassThroughToClient(conn *ConnWrapper, stack *Stack) *gerr.Gate
 		span.RecordError(errVerdict)
 	}
 
-	metrics.ProxyPassThroughsToClient.Inc()
+	metrics.ProxyPassThroughsToClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Inc()
 
 	return errVerdict
 }
@@ -716,8 +725,8 @@ func (pr *Proxy) receiveTrafficFromClient(conn net.Conn) ([]byte, *gerr.GatewayD
 			pr.Logger.Debug().Err(err).Msg("Error reading from client")
 			span.RecordError(err)
 
-			metrics.BytesReceivedFromClient.Observe(float64(read))
-			metrics.TotalTrafficBytes.Observe(float64(read))
+			metrics.BytesReceivedFromClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(read))
+			metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(read))
 
 			return chunk[:read], gerr.ErrReadFailed.Wrap(err)
 		}
@@ -744,8 +753,8 @@ func (pr *Proxy) receiveTrafficFromClient(conn net.Conn) ([]byte, *gerr.GatewayD
 
 	span.AddEvent("Received data from client")
 
-	metrics.BytesReceivedFromClient.Observe(float64(total))
-	metrics.TotalTrafficBytes.Observe(float64(total))
+	metrics.BytesReceivedFromClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(total))
+	metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(total))
 
 	return buffer.Bytes(), nil
 }
@@ -777,8 +786,8 @@ func (pr *Proxy) sendTrafficToServer(client *Client, request []byte) (int, *gerr
 
 	span.AddEvent("Sent data to database")
 
-	metrics.BytesSentToServer.Observe(float64(sent))
-	metrics.TotalTrafficBytes.Observe(float64(sent))
+	metrics.BytesSentToServer.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(sent))
+	metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(sent))
 
 	return sent, err
 }
@@ -806,8 +815,8 @@ func (pr *Proxy) receiveTrafficFromServer(client *Client) (int, []byte, *gerr.Ga
 
 	span.AddEvent("Received data from database")
 
-	metrics.BytesReceivedFromServer.Observe(float64(received))
-	metrics.TotalTrafficBytes.Observe(float64(received))
+	metrics.BytesReceivedFromServer.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(received))
+	metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(received))
 
 	return received, response, err
 }
@@ -847,8 +856,8 @@ func (pr *Proxy) sendTrafficToClient(
 
 	span.AddEvent("Sent data to client")
 
-	metrics.BytesSentToClient.Observe(float64(received))
-	metrics.TotalTrafficBytes.Observe(float64(received))
+	metrics.BytesSentToClient.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(received))
+	metrics.TotalTrafficBytes.WithLabelValues(pr.GetGroupName(), pr.GetBlockName()).Observe(float64(received))
 
 	return nil
 }

--- a/network/roundrobin_test.go
+++ b/network/roundrobin_test.go
@@ -44,8 +44,8 @@ func TestRoundRobin_NextProxy(t *testing.T) {
 		if !ok {
 			t.Fatalf("test %d: expected proxy of type MockProxy, got %T", testIndex, proxy)
 		}
-		if mockProxy.GetName() != expected {
-			t.Errorf("test %d: expected proxy name %s, got %s", testIndex, expected, mockProxy.GetName())
+		if mockProxy.GetBlockName() != expected {
+			t.Errorf("test %d: expected proxy name %s, got %s", testIndex, expected, mockProxy.GetBlockName())
 		}
 	}
 }

--- a/network/weightedroundrobin.go
+++ b/network/weightedroundrobin.go
@@ -80,7 +80,7 @@ func (r *WeightedRoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDEr
 // findProxyByName locates a proxy by its name in the provided list of proxies.
 func findProxyByName(name string, proxies []IProxy) IProxy {
 	for _, proxy := range proxies {
-		if proxy.GetName() == name {
+		if proxy.GetBlockName() == name {
 			return proxy
 		}
 	}

--- a/network/weightedroundrobin_test.go
+++ b/network/weightedroundrobin_test.go
@@ -138,7 +138,7 @@ func TestWeightedRoundRobinNextProxy(t *testing.T) {
 		mockProxy, ok := proxy.(MockProxy)
 		require.True(t, ok, "expected proxy of type MockProxy, got %T", proxy)
 
-		counts[mockProxy.GetName()]++
+		counts[mockProxy.GetBlockName()]++
 	}
 
 	// Validate that the actual distribution of requests closely matches the expected distribution.
@@ -191,7 +191,7 @@ func TestWeightedRoundRobinConcurrentAccess(t *testing.T) {
 			if assert.Nil(t, err, "No error expected when getting a proxy") {
 				// Safely update the proxy selection count using a mutex.
 				mux.Lock()
-				proxySelection[proxy.GetName()]++
+				proxySelection[proxy.GetBlockName()]++
 				mux.Unlock()
 			}
 		}()


### PR DESCRIPTION
# Ticket(s)

Closes #611.

## Description

This PR adds labels to metrics to be populated with the config group and config block names.

<details>
<summary>Exposed Prometheus Metrics</summary>

```text
# HELP gatewayd_bytes_received_from_client Number of bytes received from client
# TYPE gatewayd_bytes_received_from_client summary
gatewayd_bytes_received_from_client_sum{block="reads",group="default"} 1204
gatewayd_bytes_received_from_client_count{block="reads",group="default"} 11
gatewayd_bytes_received_from_client_sum{block="writes",group="default"} 5944
gatewayd_bytes_received_from_client_count{block="writes",group="default"} 46
# HELP gatewayd_bytes_received_from_server Number of bytes received from server
# TYPE gatewayd_bytes_received_from_server summary
gatewayd_bytes_received_from_server_sum{block="reads",group="default"} 1578
gatewayd_bytes_received_from_server_count{block="reads",group="default"} 8
gatewayd_bytes_received_from_server_sum{block="writes",group="default"} 12913
gatewayd_bytes_received_from_server_count{block="writes",group="default"} 33
# HELP gatewayd_bytes_sent_to_client Number of bytes sent to client
# TYPE gatewayd_bytes_sent_to_client summary
gatewayd_bytes_sent_to_client_sum{block="reads",group="default"} 1578
gatewayd_bytes_sent_to_client_count{block="reads",group="default"} 7
gatewayd_bytes_sent_to_client_sum{block="writes",group="default"} 12913
gatewayd_bytes_sent_to_client_count{block="writes",group="default"} 27
# HELP gatewayd_bytes_sent_to_server Number of bytes sent to server
# TYPE gatewayd_bytes_sent_to_server summary
gatewayd_bytes_sent_to_server_sum{block="reads",group="default"} 1188
gatewayd_bytes_sent_to_server_count{block="reads",group="default"} 8
gatewayd_bytes_sent_to_server_sum{block="writes",group="default"} 5888
gatewayd_bytes_sent_to_server_count{block="writes",group="default"} 33
# HELP gatewayd_client_connections Number of client connections
# TYPE gatewayd_client_connections gauge
gatewayd_client_connections{block="reads",group="default"} 1
gatewayd_client_connections{block="writes",group="default"} 1
# HELP gatewayd_plugin_hooks_executed_total Number of plugin hooks executed
# TYPE gatewayd_plugin_hooks_executed_total counter
gatewayd_plugin_hooks_executed_total 237
# HELP gatewayd_plugin_hooks_registered_total Number of plugin hooks registered
# TYPE gatewayd_plugin_hooks_registered_total counter
gatewayd_plugin_hooks_registered_total 0
# HELP gatewayd_plugins_loaded_total Number of plugins loaded
# TYPE gatewayd_plugins_loaded_total counter
gatewayd_plugins_loaded_total 0
# HELP gatewayd_proxied_connections Number of proxy connects
# TYPE gatewayd_proxied_connections gauge
gatewayd_proxied_connections{block="reads",group="default"} 1
gatewayd_proxied_connections{block="writes",group="default"} 1
# HELP gatewayd_proxy_health_checks_total Number of proxy health checks
# TYPE gatewayd_proxy_health_checks_total counter
gatewayd_proxy_health_checks_total{block="reads",group="default"} 2
gatewayd_proxy_health_checks_total{block="writes",group="default"} 2
# HELP gatewayd_proxy_passthroughs_to_client_total Number of successful proxy passthroughs from server to client
# TYPE gatewayd_proxy_passthroughs_to_client_total counter
gatewayd_proxy_passthroughs_to_client_total{block="reads",group="default"} 7
gatewayd_proxy_passthroughs_to_client_total{block="writes",group="default"} 27
# HELP gatewayd_proxy_passthroughs_to_server_total Number of successful proxy passthroughs from client to server
# TYPE gatewayd_proxy_passthroughs_to_server_total counter
gatewayd_proxy_passthroughs_to_server_total{block="reads",group="default"} 8
gatewayd_proxy_passthroughs_to_server_total{block="writes",group="default"} 33
# HELP gatewayd_server_connections Number of server connections
# TYPE gatewayd_server_connections gauge
gatewayd_server_connections{block="",group=""} -36
gatewayd_server_connections{block="reads",group="default"} 30
gatewayd_server_connections{block="writes",group="default"} 26
# HELP gatewayd_server_ticks_fired_total Total number of server ticks fired
# TYPE gatewayd_server_ticks_fired_total counter
gatewayd_server_ticks_fired_total 0
# HELP gatewayd_traffic_bytes Number of total bytes passed through GatewayD via client or server
# TYPE gatewayd_traffic_bytes summary
gatewayd_traffic_bytes_sum{block="reads",group="default"} 5548
gatewayd_traffic_bytes_count{block="reads",group="default"} 34
gatewayd_traffic_bytes_sum{block="writes",group="default"} 37658
gatewayd_traffic_bytes_count{block="writes",group="default"} 139
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.6703e-05
go_gc_duration_seconds{quantile="0.25"} 8.5377e-05
go_gc_duration_seconds{quantile="0.5"} 0.000243246
go_gc_duration_seconds{quantile="0.75"} 0.000292101
go_gc_duration_seconds{quantile="1"} 0.000323811
go_gc_duration_seconds_sum 0.001992085
go_gc_duration_seconds_count 10
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent
# TYPE go_gc_gogc_percent gauge
go_gc_gogc_percent 100
# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes
# TYPE go_gc_gomemlimit_bytes gauge
go_gc_gomemlimit_bytes 9.223372036854776e+18
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 38
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.23.1"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 8.106104e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 3.2990824e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 6321
# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 206104
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 3.446832e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 8.106104e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 8.429568e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.1444224e+07
# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 15094
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 3.915776e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 1.9873792e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.7278142067925987e+09
# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 221198
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 19200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 31200
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 183840
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 228480
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.4506984e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 2.094287e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.015808e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.015808e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.669672e+07
# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads
# TYPE go_sched_gomaxprocs_threads gauge
go_sched_gomaxprocs_threads 16
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 16
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.29
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
# TYPE process_network_receive_bytes_total counter
process_network_receive_bytes_total 2.02998181e+08
# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
# TYPE process_network_transmit_bytes_total counter
process_network_transmit_bytes_total 2.05111159e+08
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 34
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 4.5420544e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.72781407123e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 2.358419456e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 26
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

</details>

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
