### PR TITLE
Use the result of notification hooks

### DIFF
--- a/act/registry.go
+++ b/act/registry.go
@@ -407,6 +407,10 @@ func runActionWithTimeout(
 
 // RunAll run all the actions in the outputs and returns the end result.
 func (r *Registry) RunAll(result map[string]any) map[string]any {
+	if result == nil || len(result) == 0 {
+		return result
+	}
+
 	if _, exists := result[sdkAct.Outputs]; !exists {
 		r.Logger.Debug().Msg("Outputs key is not present, returning the result as-is")
 		return result

--- a/act/registry.go
+++ b/act/registry.go
@@ -407,7 +407,7 @@ func runActionWithTimeout(
 
 // RunAll run all the actions in the outputs and returns the end result.
 func (r *Registry) RunAll(result map[string]any) map[string]any {
-	if result == nil || len(result) == 0 {
+	if len(result) == 0 {
 		return result
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ func StopGracefully(
 			span.RecordError(err)
 		}
 		if result != nil {
-			_ = pluginRegistry.ActRegistry.RunAll(result)
+			_ = pluginRegistry.ActRegistry.RunAll(result) //nolint:contextcheck
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -109,7 +109,7 @@ func StopGracefully(
 		defer cancel()
 
 		//nolint:contextcheck
-		_, err := pluginRegistry.Run(
+		result, err := pluginRegistry.Run(
 			pluginTimeoutCtx,
 			map[string]any{"signal": currentSignal},
 			v1.HookName_HOOK_NAME_ON_SIGNAL,
@@ -117,6 +117,9 @@ func StopGracefully(
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to run OnSignal hooks")
 			span.RecordError(err)
+		}
+		if result != nil {
+			_ = pluginRegistry.ActRegistry.RunAll(result)
 		}
 	}
 
@@ -434,6 +437,9 @@ var runCmd = &cobra.Command{
 			logger.Error().Err(err).Msg("Failed to run OnConfigLoaded hooks")
 			span.RecordError(err)
 		}
+		if updatedGlobalConfig != nil {
+			updatedGlobalConfig = pluginRegistry.ActRegistry.RunAll(updatedGlobalConfig)
+		}
 
 		// If the config was modified by the plugins, merge it with the one loaded from the file.
 		// Only global configuration is merged, which means that plugins cannot modify the plugin
@@ -606,11 +612,14 @@ var runCmd = &cobra.Command{
 		defer cancel()
 
 		if data, ok := conf.GlobalKoanf.Get("loggers").(map[string]any); ok {
-			_, err = pluginRegistry.Run(
+			result, err := pluginRegistry.Run(
 				pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_LOGGER)
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to run OnNewLogger hooks")
 				span.RecordError(err)
+			}
+			if result != nil {
+				_ = pluginRegistry.ActRegistry.RunAll(result)
 			}
 		} else {
 			logger.Error().Msg("Failed to get loggers from config")
@@ -767,11 +776,14 @@ var runCmd = &cobra.Command{
 							"backoffMultiplier":  clientConfig.BackoffMultiplier,
 							"disableBackoffCaps": clientConfig.DisableBackoffCaps,
 						}
-						_, err := pluginRegistry.Run(
+						result, err := pluginRegistry.Run(
 							pluginTimeoutCtx, clientCfg, v1.HookName_HOOK_NAME_ON_NEW_CLIENT)
 						if err != nil {
 							logger.Error().Err(err).Msg("Failed to run OnNewClient hooks")
 							span.RecordError(err)
+						}
+						if result != nil {
+							_ = pluginRegistry.ActRegistry.RunAll(result)
 						}
 
 						err = pools[configGroupName][configBlockName].Put(client.ID, client)
@@ -822,13 +834,16 @@ var runCmd = &cobra.Command{
 					context.Background(), conf.Plugin.Timeout)
 				defer cancel()
 
-				_, err = pluginRegistry.Run(
+				result, err := pluginRegistry.Run(
 					pluginTimeoutCtx,
 					map[string]any{"name": configBlockName, "size": currentPoolSize},
 					v1.HookName_HOOK_NAME_ON_NEW_POOL)
 				if err != nil {
 					logger.Error().Err(err).Msg("Failed to run OnNewPool hooks")
 					span.RecordError(err)
+				}
+				if result != nil {
+					_ = pluginRegistry.ActRegistry.RunAll(result)
 				}
 			}
 		}
@@ -877,11 +892,14 @@ var runCmd = &cobra.Command{
 				defer cancel()
 
 				if data, ok := conf.GlobalKoanf.Get("proxies").(map[string]any); ok {
-					_, err = pluginRegistry.Run(
+					result, err := pluginRegistry.Run(
 						pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_PROXY)
 					if err != nil {
 						logger.Error().Err(err).Msg("Failed to run OnNewProxy hooks")
 						span.RecordError(err)
+					}
+					if result != nil {
+						_ = pluginRegistry.ActRegistry.RunAll(result)
 					}
 				} else {
 					logger.Error().Msg("Failed to get proxy from config")
@@ -948,11 +966,14 @@ var runCmd = &cobra.Command{
 			defer cancel()
 
 			if data, ok := conf.GlobalKoanf.Get("servers").(map[string]any); ok {
-				_, err = pluginRegistry.Run(
+				result, err := pluginRegistry.Run(
 					pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_SERVER)
 				if err != nil {
 					logger.Error().Err(err).Msg("Failed to run OnNewServer hooks")
 					span.RecordError(err)
+				}
+				if result != nil {
+					_ = pluginRegistry.ActRegistry.RunAll(result)
 				}
 			} else {
 				logger.Error().Msg("Failed to get the servers configuration")

--- a/network/server.go
+++ b/network/server.go
@@ -98,13 +98,16 @@ func (s *Server) OnBoot() Action {
 	pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), s.PluginTimeout)
 	defer cancel()
 	// Run the OnBooting hooks.
-	_, err := s.PluginRegistry.Run(
+	result, err := s.PluginRegistry.Run(
 		pluginTimeoutCtx,
 		map[string]any{"status": fmt.Sprint(s.Status)},
 		v1.HookName_HOOK_NAME_ON_BOOTING)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnBooting hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnBooting hooks")
 
@@ -117,13 +120,16 @@ func (s *Server) OnBoot() Action {
 	pluginTimeoutCtx, cancel = context.WithTimeout(context.Background(), s.PluginTimeout)
 	defer cancel()
 
-	_, err = s.PluginRegistry.Run(
+	result, err = s.PluginRegistry.Run(
 		pluginTimeoutCtx,
 		map[string]any{"status": fmt.Sprint(s.Status)},
 		v1.HookName_HOOK_NAME_ON_BOOTED)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnBooted hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnBooted hooks")
 
@@ -150,11 +156,14 @@ func (s *Server) OnOpen(conn *ConnWrapper) ([]byte, Action) {
 			"remote": RemoteAddr(conn.Conn()),
 		},
 	}
-	_, err := s.PluginRegistry.Run(
+	result, err := s.PluginRegistry.Run(
 		pluginTimeoutCtx, onOpeningData, v1.HookName_HOOK_NAME_ON_OPENING)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnOpening hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnOpening hooks")
 
@@ -195,11 +204,14 @@ func (s *Server) OnOpen(conn *ConnWrapper) ([]byte, Action) {
 			"remote": RemoteAddr(conn.Conn()),
 		},
 	}
-	_, err = s.PluginRegistry.Run(
+	result, err = s.PluginRegistry.Run(
 		pluginTimeoutCtx, onOpenedData, v1.HookName_HOOK_NAME_ON_OPENED)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnOpened hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnOpened hooks")
 
@@ -231,11 +243,14 @@ func (s *Server) OnClose(conn *ConnWrapper, err error) Action {
 	if err != nil {
 		data["error"] = err.Error()
 	}
-	_, gatewaydErr := s.PluginRegistry.Run(
+	result, gatewaydErr := s.PluginRegistry.Run(
 		pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_CLOSING)
 	if gatewaydErr != nil {
 		s.Logger.Error().Err(gatewaydErr).Msg("Failed to run OnClosing hook")
 		span.RecordError(gatewaydErr)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnClosing hooks")
 
@@ -291,11 +306,14 @@ func (s *Server) OnClose(conn *ConnWrapper, err error) Action {
 	if err != nil {
 		data["error"] = err.Error()
 	}
-	_, gatewaydErr = s.PluginRegistry.Run(
+	result, gatewaydErr = s.PluginRegistry.Run(
 		pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_CLOSED)
 	if gatewaydErr != nil {
 		s.Logger.Error().Err(gatewaydErr).Msg("Failed to run OnClosed hook")
 		span.RecordError(gatewaydErr)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnClosed hooks")
 
@@ -320,11 +338,14 @@ func (s *Server) OnTraffic(conn *ConnWrapper, stopConnection chan struct{}) Acti
 			"remote": RemoteAddr(conn.Conn()),
 		},
 	}
-	_, err := s.PluginRegistry.Run(
+	result, err := s.PluginRegistry.Run(
 		pluginTimeoutCtx, onTrafficData, v1.HookName_HOOK_NAME_ON_TRAFFIC)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnTraffic hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnTraffic hooks")
 
@@ -391,13 +412,16 @@ func (s *Server) OnShutdown() {
 	pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), s.PluginTimeout)
 	defer cancel()
 	// Run the OnShutdown hooks.
-	_, err := s.PluginRegistry.Run(
+	result, err := s.PluginRegistry.Run(
 		pluginTimeoutCtx,
 		map[string]any{"connections": s.CountConnections()},
 		v1.HookName_HOOK_NAME_ON_SHUTDOWN)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnShutdown hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnShutdown hooks")
 
@@ -424,13 +448,16 @@ func (s *Server) OnTick() (time.Duration, Action) {
 	pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), s.PluginTimeout)
 	defer cancel()
 	// Run the OnTick hooks.
-	_, err := s.PluginRegistry.Run(
+	result, err := s.PluginRegistry.Run(
 		pluginTimeoutCtx,
 		map[string]any{"connections": s.CountConnections()},
 		v1.HookName_HOOK_NAME_ON_TICK)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("Failed to run OnTick hook")
 		span.RecordError(err)
+	}
+	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
 	}
 	span.AddEvent("Ran the OnTick hooks")
 
@@ -474,6 +501,8 @@ func (s *Server) Run() *gerr.GatewayDError {
 	span.AddEvent("Ran the OnRun hooks")
 
 	if result != nil {
+		_ = s.PluginRegistry.ActRegistry.RunAll(result)
+
 		if errMsg, ok := result["error"].(string); ok && errMsg != "" {
 			s.Logger.Error().Str("error", errMsg).Msg("Error in hook")
 		}


### PR DESCRIPTION
# Ticket(s)

Closes #397.
Related to #468.

## Description

Revised version:

Previously, signals emitted by notification hooks were discarded. This PR changes that behavior by ensuring all actions are executed based on the result of all the hooks (including the notification hooks). Currently, running these actions has no immediate impact, as the results are still mostly discarded. However, once new Signals, Actions, and Policies are implemented (see #468 and https://github.com/gatewayd-io/proposals/issues/5), these results will be utilized effectively.

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
