### PR TITLE
Make PostgreSQL and Redis connection strings configurable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
-      - POSTGRE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@write-postgres:5432/${POSTGRES_DB}
+      - POSTGRES_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@write-postgres:5432/${POSTGRES_DB}
   
   write-postgres:
     image: postgres:latest
@@ -76,7 +76,7 @@ services:
       - GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS=write-postgres:5432
       - GATEWAYD_CLIENTS_DEFAULT_READS_ADDRESS=read-postgres:5432
       # Use the connection string set in install_plugins
-      - POSTGRE_URL=${POSTGRE_URL}
+      - POSTGRES_URL=${POSTGRES_URL}
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
       # GatewayD server for PostgreSQL clients to connect to

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,11 +19,18 @@ services:
       # Possible values: amd64 or arm64
       # - ARCH=amd64
       - REDIS_URL=redis://redis:6379/0
+      # Allow custom PostgreSQL connection string
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+      - POSTGRE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@write-postgres:5432/${POSTGRES_DB}
+  
   write-postgres:
     image: postgres:latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -34,11 +41,13 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres  # Ensure consistency
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
+
   redis:
     image: redis:latest
     healthcheck:
@@ -46,6 +55,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
   gatewayd:
     image: gatewaydio/gatewayd:latest
     command:
@@ -65,6 +75,8 @@ services:
       # https://docs.gatewayd.io/using-gatewayd/configuration#environment-variables
       - GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS=write-postgres:5432
       - GATEWAYD_CLIENTS_DEFAULT_READS_ADDRESS=read-postgres:5432
+      # Use the connection string set in install_plugins
+      - POSTGRE_URL=${POSTGRE_URL}
       # - GATEWAYD_LOGGERS_DEFAULT_LEVEL=debug
     ports:
       # GatewayD server for PostgreSQL clients to connect to

--- a/gatewayd_plugins.yaml
+++ b/gatewayd_plugins.yaml
@@ -39,6 +39,10 @@ actionTimeout: 30s
 
 # action redis configures a Redis connection for the async actions to be published to.
 actionRedis:
+  # enabled controls whether to enable redis as async action queue
+  enabled: false
+
+  # if enabled, the url and channel are used to connect to the Redis server.
   address: ${REDIS_URL}  # Use environment variable for Redis URL
   channel: gatewayd-actions
 

--- a/gatewayd_plugins.yaml
+++ b/gatewayd_plugins.yaml
@@ -39,11 +39,8 @@ actionTimeout: 30s
 
 # action redis configures a Redis connection for the async actions to be published to.
 actionRedis:
-  # enabled controls whether to enable redis as async action queue
-  enabled: false
-
-  # if enabled, the url and channel are used to connect to the Redis server.
-  address: localhost:6379
+  enabled: false  # Change to true to enable Redis as async action queue
+  address: ${REDIS_URL}  # Use environment variable for Redis URL
   channel: gatewayd-actions
 
 # The policy is a list of policies to apply to the signals received from the plugins.
@@ -72,7 +69,7 @@ plugins:
     env:
       - MAGIC_COOKIE_KEY=GATEWAYD_PLUGIN
       - MAGIC_COOKIE_VALUE=5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872
-      - REDIS_URL=redis://localhost:6379/0
+      - REDIS_URL=${REDIS_URL}  # Use environment variable for Redis URL
       - EXPIRY=1h
       # - DEFAULT_DB_NAME=postgres
       - METRICS_ENABLED=True

--- a/gatewayd_plugins.yaml
+++ b/gatewayd_plugins.yaml
@@ -39,7 +39,6 @@ actionTimeout: 30s
 
 # action redis configures a Redis connection for the async actions to be published to.
 actionRedis:
-  enabled: false  # Change to true to enable Redis as async action queue
   address: ${REDIS_URL}  # Use environment variable for Redis URL
   channel: gatewayd-actions
 


### PR DESCRIPTION
# Ticket(s)

Closes https://github.com/gatewayd-io/gatewayd/issues/563

## Description

Configured the `docker-compose.yaml`, `gatewayd_plugins.yaml` to read from the the Environment variables for redis and postresql url string

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [ ] I have squashed related commits together.
- [ ] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [ ] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
