### PR TITLE
Add Raft State Management for Load Balancers

### DIFF
--- a/gatewayd.yaml
+++ b/gatewayd.yaml
@@ -115,3 +115,4 @@ raft:
   peers: []
   # - id: node2
   #   address: 127.0.0.1:2223
+  #   grpcAddress: 127.0.0.1:50052

--- a/network/consistenthash.go
+++ b/network/consistenthash.go
@@ -84,7 +84,7 @@ func (ch *ConsistentHash) NextProxy(conn IConnWrapper) (IProxy, *gerr.GatewayDEr
 	}
 
 	// Apply the command through Raft
-	if err := ch.server.RaftNode.Apply(cmdBytes, raft.LeaderElectionTimeout); err != nil {
+	if err := ch.server.RaftNode.Apply(cmdBytes, raft.ApplyTimeout); err != nil {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
 	}
 

--- a/network/consistenthash_test.go
+++ b/network/consistenthash_test.go
@@ -70,10 +70,12 @@ func TestConsistentHashNextProxyUseSourceIpExists(t *testing.T) {
 	// Instead of setting hashMap directly, setup the FSM
 	hash := hashKey("192.168.1.1" + server.GroupName)
 	// Create and apply the command through Raft
-	cmd := raft.ConsistentHashCommand{
-		Type:      raft.CommandAddConsistentHashEntry,
-		Hash:      hash,
-		BlockName: proxies[2].GetBlockName(),
+	cmd := raft.Command{
+		Type: raft.CommandAddConsistentHashEntry,
+		Payload: raft.ConsistentHashPayload{
+			Hash:      hash,
+			BlockName: proxies[2].GetBlockName(),
+		},
 	}
 
 	cmdBytes, marshalErr := json.Marshal(cmd)

--- a/network/network_helpers_test.go
+++ b/network/network_helpers_test.go
@@ -242,6 +242,8 @@ func setupProxy(
 			ClientConfig:         clientConfig,
 			Logger:               logger,
 			PluginTimeout:        config.DefaultPluginTimeout,
+			GroupName:            "test-group",
+			BlockName:            clientIP + ":" + clientPort,
 		},
 	)
 

--- a/network/roundrobin.go
+++ b/network/roundrobin.go
@@ -1,21 +1,26 @@
 package network
 
 import (
+	"encoding/json"
 	"math"
-	"sync/atomic"
+	"sync"
 
 	gerr "github.com/gatewayd-io/gatewayd/errors"
+	"github.com/gatewayd-io/gatewayd/raft"
 )
 
 type RoundRobin struct {
 	proxies []IProxy
-	next    atomic.Uint32
+	server  *Server
+	mu      sync.Mutex
 }
 
+// NewRoundRobin creates a new RoundRobin load balancer.
 func NewRoundRobin(server *Server) *RoundRobin {
-	return &RoundRobin{proxies: server.Proxies}
+	return &RoundRobin{proxies: server.Proxies, server: server}
 }
 
+// NextProxy returns the next proxy in the round-robin sequence.
 func (r *RoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDError) {
 	if len(r.proxies) > math.MaxUint32 {
 		// This should never happen, but if it does, we fall back to the first proxy.
@@ -24,6 +29,32 @@ func (r *RoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDError) {
 		return nil, gerr.ErrNoProxiesAvailable
 	}
 
-	nextIndex := r.next.Add(1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Get current index from Raft FSM
+	currentIndex := r.server.RaftNode.Fsm.GetRoundRobinNext(r.server.GroupName)
+	nextIndex := currentIndex + 1
+
+	// Create Raft command
+	cmd := raft.Command{
+		Type: raft.CommandAddRoundRobinNext,
+		Payload: raft.RoundRobinPayload{
+			NextIndex: nextIndex,
+			GroupName: r.server.GroupName,
+		},
+	}
+
+	// Convert command to JSON
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
+	}
+
+	// Apply through Raft
+	if err := r.server.RaftNode.Apply(data, raft.LeaderElectionTimeout); err != nil {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
+	}
+
 	return r.proxies[nextIndex%uint32(len(r.proxies))], nil //nolint:gosec
 }

--- a/network/roundrobin.go
+++ b/network/roundrobin.go
@@ -52,7 +52,7 @@ func (r *RoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDError) {
 	}
 
 	// Apply through Raft
-	if err := r.server.RaftNode.Apply(data, raft.LeaderElectionTimeout); err != nil {
+	if err := r.server.RaftNode.Apply(data, raft.ApplyTimeout); err != nil {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
 	}
 

--- a/network/roundrobin_test.go
+++ b/network/roundrobin_test.go
@@ -144,7 +144,7 @@ func TestNextProxyOverflow(t *testing.T) {
 	data, err := json.Marshal(cmd)
 	require.NoError(t, err)
 
-	require.NoError(t, raftHelper.Node.Apply(data, raft.LeaderElectionTimeout))
+	require.NoError(t, raftHelper.Node.Apply(data, raft.ApplyTimeout))
 
 	// Call NextProxy multiple times to trigger the overflow
 	for range 4 {

--- a/network/roundrobin_test.go
+++ b/network/roundrobin_test.go
@@ -1,9 +1,14 @@
 package network
 
 import (
+	"encoding/json"
 	"math"
 	"sync"
 	"testing"
+
+	"github.com/gatewayd-io/gatewayd/raft"
+	"github.com/gatewayd-io/gatewayd/testhelpers"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewRoundRobin tests the NewRoundRobin function to ensure that it correctly initializes
@@ -25,12 +30,21 @@ func TestNewRoundRobin(t *testing.T) {
 // TestRoundRobin_NextProxy tests the NextProxy method of the round-robin load balancer to ensure
 // that it returns proxies in the expected order.
 func TestRoundRobin_NextProxy(t *testing.T) {
+	raftHelper, err := testhelpers.NewTestRaftNode(t)
+	if err != nil {
+		t.Fatalf("Failed to create test raft node: %v", err)
+	}
+	defer func() {
+		if err := raftHelper.Cleanup(); err != nil {
+			t.Errorf("Failed to cleanup raft: %v", err)
+		}
+	}()
 	proxies := []IProxy{
 		MockProxy{name: "proxy1"},
 		MockProxy{name: "proxy2"},
 		MockProxy{name: "proxy3"},
 	}
-	server := &Server{Proxies: proxies}
+	server := &Server{Proxies: proxies, RaftNode: raftHelper.Node, GroupName: "test-group"}
 	roundRobin := NewRoundRobin(server)
 
 	expectedOrder := []string{"proxy2", "proxy3", "proxy1", "proxy2", "proxy3"}
@@ -58,7 +72,18 @@ func TestRoundRobin_ConcurrentAccess(t *testing.T) {
 		MockProxy{name: "proxy2"},
 		MockProxy{name: "proxy3"},
 	}
-	server := &Server{Proxies: proxies}
+
+	raftHelper, err := testhelpers.NewTestRaftNode(t)
+	if err != nil {
+		t.Fatalf("Failed to create test raft node: %v", err)
+	}
+	defer func() {
+		if err := raftHelper.Cleanup(); err != nil {
+			t.Errorf("Failed to cleanup raft: %v", err)
+		}
+	}()
+	server := &Server{Proxies: proxies, RaftNode: raftHelper.Node, GroupName: "test-group"}
+	server.initializeProxies()
 	roundRobin := NewRoundRobin(server)
 
 	var waitGroup sync.WaitGroup
@@ -73,7 +98,7 @@ func TestRoundRobin_ConcurrentAccess(t *testing.T) {
 	}
 
 	waitGroup.Wait()
-	nextIndex := roundRobin.next.Load()
+	nextIndex := server.RaftNode.Fsm.GetRoundRobinNext(server.GroupName)
 	if nextIndex != uint32(numGoroutines) {
 		t.Errorf("expected next index to be %d, got %d", numGoroutines, nextIndex)
 	}
@@ -84,6 +109,15 @@ func TestRoundRobin_ConcurrentAccess(t *testing.T) {
 // uint32 value and ensures that the proxy selection wraps around as expected when the
 // counter overflows.
 func TestNextProxyOverflow(t *testing.T) {
+	raftHelper, err := testhelpers.NewTestRaftNode(t)
+	if err != nil {
+		t.Fatalf("Failed to create test raft node: %v", err)
+	}
+	defer func() {
+		if err := raftHelper.Cleanup(); err != nil {
+			t.Errorf("Failed to cleanup raft: %v", err)
+		}
+	}()
 	// Create a server with a few mock proxies
 	server := &Server{
 		Proxies: []IProxy{
@@ -91,11 +125,26 @@ func TestNextProxyOverflow(t *testing.T) {
 			&MockProxy{},
 			&MockProxy{},
 		},
+		GroupName: "test-group",
+		RaftNode:  raftHelper.Node,
 	}
+	server.initializeProxies()
+
 	roundRobin := NewRoundRobin(server)
 
 	// Set the next value to near the max uint32 value to force an overflow
-	roundRobin.next.Store(math.MaxUint32 - 1)
+	cmd := raft.Command{
+		Type: raft.CommandAddRoundRobinNext,
+		Payload: raft.RoundRobinPayload{
+			NextIndex: math.MaxUint32 - 1,
+			GroupName: server.GroupName,
+		},
+	}
+	// Convert command to JSON
+	data, err := json.Marshal(cmd)
+	require.NoError(t, err)
+
+	require.NoError(t, raftHelper.Node.Apply(data, raft.LeaderElectionTimeout))
 
 	// Call NextProxy multiple times to trigger the overflow
 	for range 4 {
@@ -110,7 +159,7 @@ func TestNextProxyOverflow(t *testing.T) {
 
 	// After overflow, next value should wrap around
 	expectedNextValue := uint32(2) // (MaxUint32 - 1 + 4) % ProxiesLen = 2
-	actualNextValue := roundRobin.next.Load()
+	actualNextValue := server.RaftNode.Fsm.GetRoundRobinNext(server.GroupName)
 	if actualNextValue != expectedNextValue {
 		t.Fatalf("Expected next value to be %v, got %v", expectedNextValue, actualNextValue)
 	}

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -181,10 +181,9 @@ func TestRunServer(t *testing.T) {
 		defer proxyStateMutex.Unlock()
 
 		// Check that one of the proxies has the expected state.
-		if (proxy1.AvailableConnections.Size() == 2 && proxy1.busyConnections.Size() == 1) ||
-			(proxy2.AvailableConnections.Size() == 2 && proxy2.busyConnections.Size() == 1) {
-			// One of the proxies is in the expected state.
-		} else {
+		proxyInExpectedState := (proxy1.AvailableConnections.Size() == 2 && proxy1.busyConnections.Size() == 1) ||
+			(proxy2.AvailableConnections.Size() == 2 && proxy2.busyConnections.Size() == 1)
+		if !proxyInExpectedState {
 			t.Errorf("Neither proxy is in the expected state")
 		}
 

--- a/network/weightedroundrobin.go
+++ b/network/weightedroundrobin.go
@@ -103,7 +103,10 @@ func (r *WeightedRoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDEr
 		},
 	}
 
-	data, _ := json.Marshal(cmd)
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
+	}
 	if err := r.raftNode.Apply(data, raft.LeaderElectionTimeout); err != nil {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
 	}

--- a/network/weightedroundrobin.go
+++ b/network/weightedroundrobin.go
@@ -107,7 +107,7 @@ func (r *WeightedRoundRobin) NextProxy(_ IConnWrapper) (IProxy, *gerr.GatewayDEr
 	if err != nil {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
 	}
-	if err := r.raftNode.Apply(data, raft.LeaderElectionTimeout); err != nil {
+	if err := r.raftNode.Apply(data, raft.ApplyTimeout); err != nil {
 		return nil, gerr.ErrNoProxiesAvailable.Wrap(err)
 	}
 

--- a/network/weightedroundrobin_test.go
+++ b/network/weightedroundrobin_test.go
@@ -98,7 +98,6 @@ func TestNewWeightedRoundRobin(t *testing.T) {
 // TestWeightedRoundRobinNextProxy verifies that the WeightedRoundRobin algorithm
 // correctly distributes requests among proxies according to their weights.
 func TestWeightedRoundRobinNextProxy(t *testing.T) {
-
 	raftHelper, err := testhelpers.NewTestRaftNode(t)
 	require.NoError(t, err, "Failed to create test raft node")
 

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -33,6 +33,7 @@ const (
 	maxPool                       = 3                // Maximum number of connections to pool
 	transportTimeout              = 10 * time.Second // Timeout for transport operations
 	leadershipCheckInterval       = 10 * time.Second // Interval for checking leadership status
+	ApplyTimeout                  = 2 * time.Second  // Timeout for applying commands
 )
 
 // Command represents a general command structure for all operations.

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gatewayd-io/gatewayd/config"
@@ -23,6 +24,7 @@ import (
 // Configuration constants for Raft operations.
 const (
 	CommandAddConsistentHashEntry = "ADD_CONSISTENT_HASH_ENTRY"
+	CommandAddRoundRobinNext      = "ADD_ROUND_ROBIN_NEXT"
 	RaftLeaderState               = raft.Leader
 	LeaderElectionTimeout         = 3 * time.Second
 	maxSnapshots                  = 3                // Maximum number of snapshots to retain
@@ -31,11 +33,22 @@ const (
 	leadershipCheckInterval       = 10 * time.Second // Interval for checking leadership status
 )
 
-// ConsistentHashCommand represents a command to modify the consistent hash.
-type ConsistentHashCommand struct {
-	Type      string `json:"type"`
-	Hash      uint64 `json:"hash"`
+// Command represents a general command structure for all operations.
+type Command struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+// ConsistentHashPayload represents the payload for consistent hash operations.
+type ConsistentHashPayload struct {
+	Hash      string `json:"hash"`
 	BlockName string `json:"blockName"`
+}
+
+// RoundRobinPayload represents the payload for round robin operations.
+type RoundRobinPayload struct {
+	NextIndex uint32 `json:"nextIndex"`
+	GroupName string `json:"groupName"`
 }
 
 // Node represents a node in the Raft cluster.
@@ -288,12 +301,13 @@ func (n *Node) Shutdown() error {
 
 // FSM represents the Finite State Machine for the Raft cluster.
 type FSM struct {
-	lbHashToBlockName map[uint64]string
+	lbHashToBlockName map[string]string
+	roundRobinIndex   map[string]*atomic.Uint32
 	mu                sync.RWMutex
 }
 
 // GetProxyBlock safely retrieves the block name for a given hash.
-func (f *FSM) GetProxyBlock(hash uint64) (string, bool) {
+func (f *FSM) GetProxyBlock(hash string) (string, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	if blockName, exists := f.lbHashToBlockName[hash]; exists {
@@ -302,30 +316,70 @@ func (f *FSM) GetProxyBlock(hash uint64) (string, bool) {
 	return "", false
 }
 
+// GetRoundRobinNext retrieves the next index for a given group name.
+func (f *FSM) GetRoundRobinNext(groupName string) uint32 {
+	if index, ok := f.roundRobinIndex[groupName]; ok {
+		return index.Load()
+	}
+	return 0
+}
+
 // NewFSM creates a new FSM instance.
 func NewFSM() *FSM {
 	return &FSM{
-		lbHashToBlockName: make(map[uint64]string),
+		lbHashToBlockName: make(map[string]string),
+		roundRobinIndex:   make(map[string]*atomic.Uint32),
 	}
 }
 
 // Apply implements the raft.FSM interface.
 func (f *FSM) Apply(log *raft.Log) interface{} {
-	var cmd ConsistentHashCommand
+	var cmd Command
 	if err := json.Unmarshal(log.Data, &cmd); err != nil {
 		return fmt.Errorf("failed to unmarshal command: %w", err)
 	}
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	switch cmd.Type {
 	case CommandAddConsistentHashEntry:
-		f.lbHashToBlockName[cmd.Hash] = cmd.BlockName
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		payload, err := convertPayload[ConsistentHashPayload](cmd.Payload)
+		if err != nil {
+			return fmt.Errorf("failed to convert payload: %w", err)
+		}
+		f.lbHashToBlockName[payload.Hash] = payload.BlockName
+		return nil
+	case CommandAddRoundRobinNext:
+		payload, err := convertPayload[RoundRobinPayload](cmd.Payload)
+		if err != nil {
+			return fmt.Errorf("failed to convert payload: %w", err)
+		}
+		if _, exists := f.roundRobinIndex[payload.GroupName]; !exists {
+			f.roundRobinIndex[payload.GroupName] = &atomic.Uint32{}
+		}
+		f.roundRobinIndex[payload.GroupName].Store(payload.NextIndex)
 		return nil
 	default:
 		return fmt.Errorf("unknown command type: %s", cmd.Type)
 	}
+}
+
+// Helper function to convert interface{} to specific payload type.
+func convertPayload[T any](payload interface{}) (T, error) {
+	var result T
+
+	// Convert the payload to JSON
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return result, fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	// Unmarshal into the specific type
+	if err := json.Unmarshal(payloadBytes, &result); err != nil {
+		return result, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	return result, nil
 }
 
 // Snapshot returns a snapshot of the FSM.
@@ -333,44 +387,71 @@ func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	// Create a copy of the hash map
-	hashMapCopy := make(map[uint64]string)
+	// Create copies of both maps
+	hashMapCopy := make(map[string]string)
 	for k, v := range f.lbHashToBlockName {
 		hashMapCopy[k] = v
 	}
 
-	return &FSMSnapshot{lbHashToBlockName: hashMapCopy}, nil
+	roundRobinCopy := make(map[string]uint32)
+	for k, v := range f.roundRobinIndex {
+		roundRobinCopy[k] = v.Load()
+	}
+
+	return &FSMSnapshot{
+		lbHashToBlockName: hashMapCopy,
+		roundRobinIndex:   roundRobinCopy,
+	}, nil
 }
 
 // Restore restores the FSM from a snapshot.
-func (f *FSM) Restore(rc io.ReadCloser) error {
-	decoder := json.NewDecoder(rc)
-	var lbHashToBlockName map[uint64]string
-	if err := decoder.Decode(&lbHashToBlockName); err != nil {
+func (f *FSM) Restore(readCloser io.ReadCloser) error {
+	var data struct {
+		HashToBlock map[string]string `json:"hashToBlock"`
+		RoundRobin  map[string]uint32 `json:"roundRobin"`
+	}
+
+	if err := json.NewDecoder(readCloser).Decode(&data); err != nil {
 		return fmt.Errorf("error decoding snapshot: %w", err)
 	}
 
 	f.mu.Lock()
-	f.lbHashToBlockName = lbHashToBlockName
-	f.mu.Unlock()
+	defer f.mu.Unlock()
+
+	f.lbHashToBlockName = data.HashToBlock
+	f.roundRobinIndex = make(map[string]*atomic.Uint32)
+	for k, v := range data.RoundRobin {
+		atomicVal := &atomic.Uint32{}
+		atomicVal.Store(v)
+		f.roundRobinIndex[k] = atomicVal
+	}
 
 	return nil
 }
 
 // FSMSnapshot represents a snapshot of the FSM.
 type FSMSnapshot struct {
-	lbHashToBlockName map[uint64]string
+	lbHashToBlockName map[string]string
+	roundRobinIndex   map[string]uint32
 }
 
 // Persist writes the FSMSnapshot data to the given SnapshotSink.
 func (f *FSMSnapshot) Persist(sink raft.SnapshotSink) error {
-	err := json.NewEncoder(sink).Encode(f.lbHashToBlockName)
-	if err != nil {
+	data := struct {
+		HashToBlock map[string]string `json:"hashToBlock"`
+		RoundRobin  map[string]uint32 `json:"roundRobin"`
+	}{
+		HashToBlock: f.lbHashToBlockName,
+		RoundRobin:  f.roundRobinIndex,
+	}
+
+	if err := json.NewEncoder(sink).Encode(data); err != nil {
 		if cancelErr := sink.Cancel(); cancelErr != nil {
 			return fmt.Errorf("error canceling snapshot: %w (original error: %w)", cancelErr, err)
 		}
 		return fmt.Errorf("error encoding snapshot: %w", err)
 	}
+
 	if err := sink.Close(); err != nil {
 		return fmt.Errorf("error closing snapshot sink: %w", err)
 	}

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -270,3 +270,189 @@ func TestRaftLeadershipAndFollowers(t *testing.T) {
 	}
 	assert.Equal(t, 1, newLeaderCount, "Expected exactly one new leader after original leader shutdown")
 }
+
+func TestWeightedRROperations(t *testing.T) {
+	fsm := NewFSM()
+
+	// Test updating weighted round robin
+	cmd := Command{
+		Type: CommandUpdateWeightedRR,
+		Payload: WeightedRRPayload{
+			GroupName: "test-group",
+			ProxyName: "proxy1",
+			Weight: WeightedProxy{
+				CurrentWeight:   10,
+				EffectiveWeight: 20,
+			},
+		},
+	}
+
+	data, err := json.Marshal(cmd)
+	require.NoError(t, err)
+
+	// Apply the command
+	result := fsm.Apply(&raft.Log{Data: data})
+	assert.Nil(t, result)
+
+	// Test retrieving the weight
+	weight, exists := fsm.GetWeightedRRState("test-group", "proxy1")
+	assert.True(t, exists)
+	assert.Equal(t, WeightedProxy{CurrentWeight: 10, EffectiveWeight: 20}, weight)
+
+	// Test batch update
+	batchCmd := Command{
+		Type: CommandUpdateWeightedRRBatch,
+		Payload: WeightedRRBatchPayload{
+			GroupName: "test-group",
+			Updates: map[string]WeightedProxy{
+				"proxy1": {CurrentWeight: 15, EffectiveWeight: 25},
+				"proxy2": {CurrentWeight: 20, EffectiveWeight: 30},
+			},
+		},
+	}
+
+	data, err = json.Marshal(batchCmd)
+	require.NoError(t, err)
+
+	result = fsm.Apply(&raft.Log{Data: data})
+	assert.Nil(t, result)
+
+	// Verify batch updates
+	weight, exists = fsm.GetWeightedRRState("test-group", "proxy1")
+	assert.True(t, exists)
+	assert.Equal(t, WeightedProxy{CurrentWeight: 15, EffectiveWeight: 25}, weight)
+
+	weight, exists = fsm.GetWeightedRRState("test-group", "proxy2")
+	assert.True(t, exists)
+	assert.Equal(t, WeightedProxy{CurrentWeight: 20, EffectiveWeight: 30}, weight)
+}
+
+func TestRoundRobinOperations(t *testing.T) {
+	fsm := NewFSM()
+
+	// Test adding round robin index
+	cmd := Command{
+		Type: CommandAddRoundRobinNext,
+		Payload: RoundRobinPayload{
+			GroupName: "test-group",
+			NextIndex: 5,
+		},
+	}
+
+	data, err := json.Marshal(cmd)
+	require.NoError(t, err)
+
+	// Apply the command
+	result := fsm.Apply(&raft.Log{Data: data})
+	assert.Nil(t, result)
+
+	// Test retrieving the index
+	index := fsm.GetRoundRobinNext("test-group")
+	assert.Equal(t, uint32(5), index)
+
+	// Test non-existent group
+	index = fsm.GetRoundRobinNext("non-existent")
+	assert.Equal(t, uint32(0), index)
+}
+
+func TestFSMInvalidCommands(t *testing.T) {
+	fsm := NewFSM()
+
+	// Test invalid command type
+	cmd := Command{
+		Type:    "INVALID_COMMAND",
+		Payload: nil,
+	}
+
+	data, err := json.Marshal(cmd)
+	require.NoError(t, err)
+
+	result := fsm.Apply(&raft.Log{Data: data})
+	err, isError := result.(error)
+	assert.True(t, isError, "expected result to be an error")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command type")
+
+	// Test invalid payload
+	cmd = Command{
+		Type:    CommandAddConsistentHashEntry,
+		Payload: "invalid payload",
+	}
+
+	data, err = json.Marshal(cmd)
+	require.NoError(t, err)
+
+	result = fsm.Apply(&raft.Log{Data: data})
+	err, isError = result.(error)
+	assert.True(t, isError, "expected result to be an error")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to convert payload")
+}
+
+func TestFSMRestoreSnapshot(t *testing.T) {
+	fsm := NewFSM()
+
+	// Create test data
+	testData := struct {
+		HashToBlock     map[string]string                   `json:"hashToBlock"`
+		RoundRobin      map[string]uint32                   `json:"roundRobin"`
+		WeightedRRState map[string]map[string]WeightedProxy `json:"weightedRrState"`
+	}{
+		HashToBlock: map[string]string{"test-hash": "test-block"},
+		RoundRobin:  map[string]uint32{"test-group": 5},
+		WeightedRRState: map[string]map[string]WeightedProxy{
+			"test-group": {
+				"proxy1": {CurrentWeight: 10, EffectiveWeight: 20},
+			},
+		},
+	}
+
+	// Create a pipe to simulate snapshot reading
+	reader, writer := io.Pipe()
+
+	// Write test data in a goroutine
+	go func() {
+		encoder := json.NewEncoder(writer)
+		err := encoder.Encode(testData)
+		assert.NoError(t, err)
+		writer.Close()
+	}()
+
+	// Restore from snapshot
+	err := fsm.Restore(reader)
+	assert.NoError(t, err)
+
+	// Verify restored data
+	blockName, exists := fsm.GetProxyBlock("test-hash")
+	assert.True(t, exists)
+	assert.Equal(t, "test-block", blockName)
+
+	index := fsm.GetRoundRobinNext("test-group")
+	assert.Equal(t, uint32(5), index)
+
+	weight, exists := fsm.GetWeightedRRState("test-group", "proxy1")
+	assert.True(t, exists)
+	assert.Equal(t, WeightedProxy{CurrentWeight: 10, EffectiveWeight: 20}, weight)
+}
+
+func TestNodeShutdown(t *testing.T) {
+	logger := setupTestLogger()
+	tempDir := t.TempDir()
+
+	config := config.Raft{
+		NodeID:      "shutdown-test-node",
+		Address:     "127.0.0.1:0",
+		IsBootstrap: true,
+		Directory:   tempDir,
+	}
+
+	node, err := NewRaftNode(logger, config)
+	require.NoError(t, err)
+
+	// Test multiple shutdowns
+	err = node.Shutdown()
+	assert.NoError(t, err)
+
+	err = node.Shutdown()
+	assert.NoError(t, err) // Should not error on multiple shutdowns
+}

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -71,10 +71,12 @@ func TestFSMOperations(t *testing.T) {
 	fsm := NewFSM()
 
 	// Test adding a hash mapping
-	cmd := ConsistentHashCommand{
-		Type:      CommandAddConsistentHashEntry,
-		Hash:      12345,
-		BlockName: "test-block",
+	cmd := Command{
+		Type: CommandAddConsistentHashEntry,
+		Payload: ConsistentHashPayload{
+			Hash:      "12345",
+			BlockName: "test-block",
+		},
 	}
 
 	data, err := json.Marshal(cmd)
@@ -85,12 +87,12 @@ func TestFSMOperations(t *testing.T) {
 	assert.Nil(t, result)
 
 	// Test retrieving the mapping
-	blockName, exists := fsm.GetProxyBlock(12345)
+	blockName, exists := fsm.GetProxyBlock("12345")
 	assert.True(t, exists)
 	assert.Equal(t, "test-block", blockName)
 
 	// Test non-existent mapping
-	blockName, exists = fsm.GetProxyBlock(99999)
+	blockName, exists = fsm.GetProxyBlock("99999")
 	assert.False(t, exists)
 	assert.Empty(t, blockName)
 }
@@ -99,10 +101,12 @@ func TestFSMSnapshot(t *testing.T) {
 	fsm := NewFSM()
 
 	// Add some data
-	cmd := ConsistentHashCommand{
-		Type:      CommandAddConsistentHashEntry,
-		Hash:      12345,
-		BlockName: "test-block",
+	cmd := Command{
+		Type: CommandAddConsistentHashEntry,
+		Payload: ConsistentHashPayload{
+			Hash:      "12345",
+			BlockName: "test-block",
+		},
 	}
 	data, err := json.Marshal(cmd)
 	require.NoError(t, err)
@@ -116,7 +120,7 @@ func TestFSMSnapshot(t *testing.T) {
 	// Verify snapshot data
 	fsmSnapshot, ok := snapshot.(*FSMSnapshot)
 	assert.True(t, ok)
-	assert.Equal(t, "test-block", fsmSnapshot.lbHashToBlockName[12345])
+	assert.Equal(t, "test-block", fsmSnapshot.lbHashToBlockName["12345"])
 }
 
 func TestRaftNodeApply(t *testing.T) {
@@ -136,10 +140,12 @@ func TestRaftNodeApply(t *testing.T) {
 	}()
 
 	// Test applying data
-	cmd := ConsistentHashCommand{
-		Type:      CommandAddConsistentHashEntry,
-		Hash:      12345,
-		BlockName: "test-block",
+	cmd := Command{
+		Type: CommandAddConsistentHashEntry,
+		Payload: ConsistentHashPayload{
+			Hash:      "12345",
+			BlockName: "test-block",
+		},
 	}
 	data, err := json.Marshal(cmd)
 	require.NoError(t, err)
@@ -224,10 +230,12 @@ func TestRaftLeadershipAndFollowers(t *testing.T) {
 	}
 
 	// Test 3: Test cluster functionality by applying a command
-	cmd := ConsistentHashCommand{
-		Type:      CommandAddConsistentHashEntry,
-		Hash:      12345,
-		BlockName: "test-block",
+	cmd := Command{
+		Type: CommandAddConsistentHashEntry,
+		Payload: ConsistentHashPayload{
+			Hash:      "12345",
+			BlockName: "test-block",
+		},
 	}
 	data, err := json.Marshal(cmd)
 	require.NoError(t, err)
@@ -241,7 +249,7 @@ func TestRaftLeadershipAndFollowers(t *testing.T) {
 
 	// Verify that all nodes have the update
 	for i, node := range nodes {
-		blockName, exists := node.Fsm.GetProxyBlock(12345)
+		blockName, exists := node.Fsm.GetProxyBlock("12345")
 		assert.True(t, exists, "Node %d should have the replicated data", i+1)
 		assert.Equal(t, "test-block", blockName, "Node %d has incorrect data", i+1)
 	}


### PR DESCRIPTION
# Ticket(s)
N/A

## Description
Add Raft State Management for Load Balancers

This PR enhances the distributed state management capabilities by integrating load balancer states into the Raft consensus system. Key changes include:

- Refactored RoundRobin and WeightedRoundRobin load balancers to store state in Raft FSM
- Updated ConsistentHash to use string-based hash keys instead of uint64
  - This change addresses a known JSON unmarshaling issue ([reference](https://docs.google.com/document/d/1UEhEclrek-zg2hsJ7g2L1beC_9hsIS3KZoM8RfDfBs0/edit?tab=t.0)) where `json.Unmarshal` uses floats when unmarshalling numbers into interface values
  - Using string-based keys provides better compatibility and prevents potential precision loss while maintaining performance through string-based dictionary lookups
- Introduced new Raft commands for load balancer state management:
  - `CommandAddRoundRobinNext`
  - `CommandUpdateWeightedRR`
  - `CommandUpdateWeightedRRBatch`
- Added proper state persistence and restoration in Raft snapshots
- Updated tests to use Raft for state management
- Improved thread safety with proper mutex usage

These changes ensure consistent load balancer behavior across the cluster by maintaining state through Raft consensus.

## Related PRs

## Development Checklist

- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
