### PR TITLE
Add Raft Node Support for Health Checks and Metrics Collection

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/network"
 	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/pool"
+	"github.com/gatewayd-io/gatewayd/raft"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc/codes"
@@ -27,6 +28,7 @@ type Options struct {
 	GRPCAddress string
 	HTTPAddress string
 	Servers     map[string]*network.Server
+	RaftNode    *raft.Node
 }
 
 type API struct {

--- a/api/healthcheck.go
+++ b/api/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gatewayd-io/gatewayd/network"
+	"github.com/gatewayd-io/gatewayd/raft"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -12,14 +13,15 @@ import (
 type HealthChecker struct {
 	grpc_health_v1.UnimplementedHealthServer
 
-	Servers map[string]*network.Server
+	Servers  map[string]*network.Server
+	raftNode *raft.Node
 }
 
 func (h *HealthChecker) Check(
 	context.Context, *grpc_health_v1.HealthCheckRequest,
 ) (*grpc_health_v1.HealthCheckResponse, error) {
 	// Check if all servers are running
-	if liveness(h.Servers) {
+	if liveness(h.Servers, h.raftNode) {
 		return &grpc_health_v1.HealthCheckResponse{
 			Status: grpc_health_v1.HealthCheckResponse_SERVING,
 		}, nil

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -63,7 +63,7 @@ func createHTTPAPI(options *Options) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/", rmux)
 	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, _ *http.Request) {
-		if liveness(options.Servers) {
+		if liveness(options.Servers, options.RaftNode) {
 			writer.Header().Set("Content-Type", "application/json")
 			writer.WriteHeader(http.StatusOK)
 			if err := json.NewEncoder(writer).Encode(Healthz{Status: "SERVING"}); err != nil {

--- a/api/utils.go
+++ b/api/utils.go
@@ -2,11 +2,17 @@ package api
 
 import (
 	"github.com/gatewayd-io/gatewayd/network"
+	"github.com/gatewayd-io/gatewayd/raft"
 )
 
-func liveness(servers map[string]*network.Server) bool {
+func liveness(servers map[string]*network.Server, raftNode *raft.Node) bool {
 	for _, v := range servers {
 		if !v.IsRunning() {
+			return false
+		}
+	}
+	if raftNode != nil {
+		if !raftNode.GetHealthStatus().IsHealthy {
 			return false
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1003,6 +1003,7 @@ var runCmd = &cobra.Command{
 				GRPCAddress: conf.Global.API.GRPCAddress,
 				HTTPAddress: conf.Global.API.HTTPAddress,
 				Servers:     servers,
+				RaftNode:    raftNode,
 			}
 
 			apiObj := &api.API{

--- a/docker-compose-raft.yaml
+++ b/docker-compose-raft.yaml
@@ -74,6 +74,7 @@ services:
       - "19090:19090"
       - "42223:2223"
       - "50051:50051"
+      - "29090:9090"
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
       - ./raft-data-1:/var/lib/gatewayd/raft
@@ -124,9 +125,28 @@ services:
       - "19091:19090"
       - "42224:2223"
       - "50052:50051"
+      - "29091:9090"
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
       - ./raft-data-2:/var/lib/gatewayd/raft
+    links:
+      - write-postgres
+      - read-postgres
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://gatewayd-2:18080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      write-postgres:
+        condition: service_healthy
+      read-postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      install_plugins:
+        condition: service_completed_successfully
 
   gatewayd-3:
     image: gatewaydio/gatewayd:latest
@@ -156,10 +176,28 @@ services:
       - "19092:19090"
       - "42225:2223"
       - "50053:50051"
+      - "29092:9090"
     volumes:
       - ./gatewayd-files:/gatewayd-files:ro
       - ./raft-data-3:/var/lib/gatewayd/raft
-
+    links:
+      - write-postgres
+      - read-postgres
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://gatewayd-3:18080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      write-postgres:
+        condition: service_healthy
+      read-postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      install_plugins:
+        condition: service_completed_successfully
   prometheus:
     image: prom/prometheus:latest
     volumes:

--- a/metrics/builtins.go
+++ b/metrics/builtins.go
@@ -105,4 +105,28 @@ var (
 		Name:      "api_requests_errors_total",
 		Help:      "Number of API request errors",
 	}, []string{"method", "endpoint", "error"})
+	RaftHealthStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "gatewayd",
+			Name:      "raft_health_status",
+			Help:      "Current health status of the Raft node (1 if healthy, 0 if unhealthy)",
+		},
+		[]string{"node_id"},
+	)
+	RaftLeaderStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "gatewayd",
+			Name:      "raft_leader_status",
+			Help:      "Indicates if this node is the current Raft leader (1) or follower (0)",
+		},
+		[]string{"node_id"},
+	)
+	RaftLastContactLatency = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "gatewayd",
+			Name:      "raft_last_contact_seconds",
+			Help:      "Time since last contact with the Raft leader in seconds",
+		},
+		[]string{"node_id"},
+	)
 )

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -575,6 +575,7 @@ type HealthStatus struct {
 	Error       error
 }
 
+// GetHealthStatus returns the health status of the Raft node.
 func (n *Node) GetHealthStatus() HealthStatus {
 	// Handle uninitialized raft node
 	if n == nil || n.raft == nil {
@@ -584,7 +585,6 @@ func (n *Node) GetHealthStatus() HealthStatus {
 		}
 	}
 
-	// Cache commonly used values
 	raftState := n.raft.State()
 	stats := n.raft.Stats()
 	nodeID := string(n.config.LocalID)

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -590,9 +590,9 @@ func (n *Node) GetHealthStatus() HealthStatus {
 	nodeID := string(n.config.LocalID)
 
 	// Determine leadership status
-	_, leaderId := n.raft.LeaderWithID()
+	_, leaderID := n.raft.LeaderWithID()
 	isLeader := raftState == raft.Leader
-	hasLeader := leaderId != ""
+	hasLeader := leaderID != ""
 
 	// Update metrics for leadership status
 	metrics.RaftLeaderStatus.WithLabelValues(nodeID).Set(boolToFloat(isLeader))
@@ -619,7 +619,7 @@ func (n *Node) GetHealthStatus() HealthStatus {
 	}
 }
 
-// Helper function to parse last contact time safely
+// Helper function to parse last contact time safely.
 func parseLastContact(value string) (time.Duration, error) {
 	switch value {
 	case "", "never":
@@ -629,13 +629,13 @@ func parseLastContact(value string) (time.Duration, error) {
 	default:
 		duration, err := time.ParseDuration(value)
 		if err != nil {
-			return 0, fmt.Errorf("invalid last_contact format: %v", err)
+			return 0, fmt.Errorf("invalid last_contact format: %w", err)
 		}
 		return duration, nil
 	}
 }
 
-// Convert bool to float for metric values
+// Convert bool to float for metric values.
 func boolToFloat(val bool) float64 {
 	if val {
 		return 1


### PR DESCRIPTION
# Ticket(s)
- [Enhance Raft Cluster Management with Health Checks, Dynamic Peer Management, and Security](https://github.com/gatewayd-io/gatewayd/issues/642)

## Description
This pull request addresses the Raft Health Check Integration as part of the enhancements needed for the Raft cluster management. The following changes have been made:
- Added Raft-specific health checks to the existing health check endpoint.
- Included leader election status in health checks.
- Added cluster state validation in health checks.
- Exposed metrics about Raft cluster health, including health status, leader status, and last contact latency.
- Updated the `liveness` function to incorporate Raft node health checks.
- Enhanced test coverage for health checks with Raft nodes.
- Updated `docker-compose-raft.yaml` to include health checks for services.

## Development Checklist
- [X] I have added a descriptive title to this PR.
- [X] I have squashed related commits together.
- [X] I have rebased my branch on top of the latest main branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [X] I have added tests for my changes.
- [X] I have signed all the commits.

## Legal Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [X] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [X] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [X] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
