### PR TITLE
Refactor commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ gatewayd-files/
 cmd/gatewayd-plugin-cache-linux-amd64-*
 tempo-data
 
+# Raft files
+raft/node*/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tempo-data
 
 # Raft files
 raft/node*/
+
+# Accidental installation of plugin
+plugins/gatewayd-plugin-cache

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   enable-all: true
   disable:
     - cyclop
+    - dupl
     - wsl
     - godox
     - gochecknoglobals

--- a/api/api_helpers_test.go
+++ b/api/api_helpers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // getAPIConfig returns a new API configuration with all the necessary components.
-func getAPIConfig() *API {
+func getAPIConfig(httpAddr, grpcAddr string) *API {
 	logger := zerolog.New(nil)
 	defaultPool := pool.NewPool(context.Background(), config.DefaultPoolSize)
 	pluginReg := plugin.NewRegistry(
@@ -60,8 +60,8 @@ func getAPIConfig() *API {
 	return &API{
 		Options: &Options{
 			GRPCNetwork: "tcp",
-			GRPCAddress: "localhost:19090",
-			HTTPAddress: "localhost:18080",
+			GRPCAddress: grpcAddr,
+			HTTPAddress: httpAddr,
 			Logger:      logger,
 			Servers:     servers,
 		},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -30,9 +30,9 @@ func TestGetVersion(t *testing.T) {
 
 func TestGetGlobalConfig(t *testing.T) {
 	// Load config from the default config file.
-	conf := config.NewConfig(context.TODO(),
+	conf := config.NewConfig(context.Background(),
 		config.Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	gerr := conf.InitConfig(context.TODO())
+	gerr := conf.InitConfig(context.Background())
 	require.Nil(t, gerr)
 	assert.NotEmpty(t, conf.Global)
 
@@ -55,9 +55,9 @@ func TestGetGlobalConfig(t *testing.T) {
 
 func TestGetGlobalConfigWithGroupName(t *testing.T) {
 	// Load config from the default config file.
-	conf := config.NewConfig(context.TODO(),
+	conf := config.NewConfig(context.Background(),
 		config.Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	gerr := conf.InitConfig(context.TODO())
+	gerr := conf.InitConfig(context.Background())
 	require.Nil(t, gerr)
 	assert.NotEmpty(t, conf.Global)
 
@@ -88,9 +88,9 @@ func TestGetGlobalConfigWithGroupName(t *testing.T) {
 
 func TestGetGlobalConfigWithNonExistingGroupName(t *testing.T) {
 	// Load config from the default config file.
-	conf := config.NewConfig(context.TODO(),
+	conf := config.NewConfig(context.Background(),
 		config.Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	gerr := conf.InitConfig(context.TODO())
+	gerr := conf.InitConfig(context.Background())
 	require.Nil(t, gerr)
 	assert.NotEmpty(t, conf.Global)
 
@@ -106,9 +106,9 @@ func TestGetGlobalConfigWithNonExistingGroupName(t *testing.T) {
 
 func TestGetPluginConfig(t *testing.T) {
 	// Load config from the default config file.
-	conf := config.NewConfig(context.TODO(),
+	conf := config.NewConfig(context.Background(),
 		config.Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	gerr := conf.InitConfig(context.TODO())
+	gerr := conf.InitConfig(context.Background())
 	require.Nil(t, gerr)
 	assert.NotEmpty(t, conf.Global)
 
@@ -135,7 +135,7 @@ func TestGetPlugins(t *testing.T) {
 			Logger:               zerolog.Logger{},
 		})
 	pluginRegistry := plugin.NewRegistry(
-		context.TODO(),
+		context.Background(),
 		plugin.Registry{
 			ActRegistry:   actRegistry,
 			Compatibility: config.Loose,
@@ -190,7 +190,7 @@ func TestGetPluginsWithEmptyPluginRegistry(t *testing.T) {
 			Logger:               zerolog.Logger{},
 		})
 	pluginRegistry := plugin.NewRegistry(
-		context.TODO(),
+		context.Background(),
 		plugin.Registry{
 			ActRegistry:   actRegistry,
 			Compatibility: config.Loose,
@@ -212,7 +212,7 @@ func TestGetPluginsWithEmptyPluginRegistry(t *testing.T) {
 func TestPools(t *testing.T) {
 	api := API{
 		Pools: map[string]map[string]*pool.Pool{
-			config.Default: {config.DefaultConfigurationBlock: pool.NewPool(context.TODO(), config.EmptyPoolCapacity)},
+			config.Default: {config.DefaultConfigurationBlock: pool.NewPool(context.Background(), config.EmptyPoolCapacity)},
 		},
 		ctx: context.Background(),
 	}
@@ -247,13 +247,13 @@ func TestGetProxies(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(context.TODO(), clientConfig, zerolog.Logger{}, nil)
+	client := network.NewClient(context.Background(), clientConfig, zerolog.Logger{}, nil)
 	require.NotNil(t, client)
-	newPool := pool.NewPool(context.TODO(), 1)
+	newPool := pool.NewPool(context.Background(), 1)
 	assert.Nil(t, newPool.Put(client.ID, client))
 
 	proxy := network.NewProxy(
-		context.TODO(),
+		context.Background(),
 		network.Proxy{
 			AvailableConnections: newPool,
 			HealthCheckPeriod:    config.DefaultHealthCheckPeriod,
@@ -299,13 +299,13 @@ func TestGetServers(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(context.TODO(), clientConfig, zerolog.Logger{}, nil)
-	newPool := pool.NewPool(context.TODO(), 1)
+	client := network.NewClient(context.Background(), clientConfig, zerolog.Logger{}, nil)
+	newPool := pool.NewPool(context.Background(), 1)
 	require.NotNil(t, newPool)
 	assert.Nil(t, newPool.Put(client.ID, client))
 
 	proxy := network.NewProxy(
-		context.TODO(),
+		context.Background(),
 		network.Proxy{
 			AvailableConnections: newPool,
 			HealthCheckPeriod:    config.DefaultHealthCheckPeriod,
@@ -330,7 +330,7 @@ func TestGetServers(t *testing.T) {
 		})
 
 	pluginRegistry := plugin.NewRegistry(
-		context.TODO(),
+		context.Background(),
 		plugin.Registry{
 			ActRegistry:   actRegistry,
 			Compatibility: config.Loose,
@@ -340,7 +340,7 @@ func TestGetServers(t *testing.T) {
 	)
 
 	server := network.NewServer(
-		context.TODO(),
+		context.Background(),
 		network.Server{
 			Network:      config.DefaultNetwork,
 			Address:      postgresAddress,

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	v1 "github.com/gatewayd-io/gatewayd/api/v1"
@@ -41,7 +42,7 @@ func NewGRPCServer(ctx context.Context, server GRPCServer) *GRPCServer {
 
 // Start starts the gRPC server.
 func (s *GRPCServer) Start() {
-	if err := s.grpcServer.Serve(s.listener); err != nil {
+	if err := s.grpcServer.Serve(s.listener); err != nil && !errors.Is(err, net.ErrClosed) {
 		s.API.Options.Logger.Err(err).Msg("failed to start gRPC API")
 	}
 }
@@ -55,7 +56,7 @@ func (s *GRPCServer) Shutdown(_ context.Context) {
 // createGRPCAPI creates a new gRPC API server and listener.
 func createGRPCAPI(api *API, healthchecker *HealthChecker) (*grpc.Server, net.Listener) {
 	listener, err := net.Listen(api.Options.GRPCNetwork, api.Options.GRPCAddress)
-	if err != nil {
+	if err != nil && !errors.Is(err, net.ErrClosed) {
 		api.Options.Logger.Err(err).Msg("failed to start gRPC API")
 		return nil, nil
 	}

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -48,9 +48,11 @@ func (s *GRPCServer) Start() {
 }
 
 // Shutdown shuts down the gRPC server.
-func (s *GRPCServer) Shutdown(_ context.Context) {
-	s.listener.Close()
-	s.grpcServer.Stop()
+func (s *GRPCServer) Shutdown(context.Context) {
+	if err := s.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		s.API.Options.Logger.Err(err).Msg("failed to close listener")
+	}
+	s.grpcServer.GracefulStop()
 }
 
 // createGRPCAPI creates a new gRPC API server and listener.

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -41,12 +41,15 @@ func NewGRPCServer(ctx context.Context, server GRPCServer) *GRPCServer {
 
 // Start starts the gRPC server.
 func (s *GRPCServer) Start() {
-	s.start(s.API, s.grpcServer, s.listener)
+	if err := s.grpcServer.Serve(s.listener); err != nil {
+		s.API.Options.Logger.Err(err).Msg("failed to start gRPC API")
+	}
 }
 
 // Shutdown shuts down the gRPC server.
 func (s *GRPCServer) Shutdown(_ context.Context) {
-	s.shutdown(s.grpcServer)
+	s.listener.Close()
+	s.grpcServer.Stop()
 }
 
 // createGRPCAPI creates a new gRPC API server and listener.
@@ -63,16 +66,4 @@ func createGRPCAPI(api *API, healthchecker *HealthChecker) (*grpc.Server, net.Li
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthchecker)
 
 	return grpcServer, listener
-}
-
-// start starts the gRPC API.
-func (s *GRPCServer) start(api *API, grpcServer *grpc.Server, listener net.Listener) {
-	if err := grpcServer.Serve(listener); err != nil {
-		api.Options.Logger.Err(err).Msg("failed to start gRPC API")
-	}
-}
-
-// shutdown shuts down the gRPC API.
-func (s *GRPCServer) shutdown(grpcServer *grpc.Server) {
-	grpcServer.GracefulStop()
 }

--- a/api/grpc_server_test.go
+++ b/api/grpc_server_test.go
@@ -14,7 +14,10 @@ import (
 
 // Test_GRPC_Server tests the gRPC server.
 func Test_GRPC_Server(t *testing.T) {
-	api := getAPIConfig()
+	api := getAPIConfig(
+		"localhost:18081",
+		"localhost:19091",
+	)
 	healthchecker := &HealthChecker{Servers: api.Servers}
 	grpcServer := NewGRPCServer(
 		context.Background(), GRPCServer{API: api, HealthChecker: healthchecker})
@@ -25,7 +28,7 @@ func Test_GRPC_Server(t *testing.T) {
 	}(grpcServer)
 
 	grpcClient, err := grpc.NewClient(
-		"localhost:19090", grpc.WithTransportCredentials(insecure.NewCredentials()))
+		"localhost:19091", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err)
 	defer grpcClient.Close()
 

--- a/api/grpc_server_test.go
+++ b/api/grpc_server_test.go
@@ -39,5 +39,5 @@ func Test_GRPC_Server(t *testing.T) {
 	assert.Equal(t, config.Version, resp.GetVersion())
 	assert.Equal(t, config.VersionInfo(), resp.GetVersionInfo())
 
-	grpcServer.Shutdown(context.Background())
+	grpcServer.Shutdown(nil)
 }

--- a/api/grpc_server_test.go
+++ b/api/grpc_server_test.go
@@ -39,5 +39,5 @@ func Test_GRPC_Server(t *testing.T) {
 	assert.Equal(t, config.Version, resp.GetVersion())
 	assert.Equal(t, config.VersionInfo(), resp.GetVersionInfo())
 
-	grpcServer.Shutdown(nil)
+	grpcServer.Shutdown(nil) //nolint:staticcheck
 }

--- a/api/healthcheck_test.go
+++ b/api/healthcheck_test.go
@@ -24,13 +24,13 @@ func Test_Healthchecker(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(context.TODO(), clientConfig, zerolog.Logger{}, nil)
-	newPool := pool.NewPool(context.TODO(), 1)
+	client := network.NewClient(context.Background(), clientConfig, zerolog.Logger{}, nil)
+	newPool := pool.NewPool(context.Background(), 1)
 	require.NotNil(t, newPool)
 	assert.Nil(t, newPool.Put(client.ID, client))
 
 	proxy := network.NewProxy(
-		context.TODO(),
+		context.Background(),
 		network.Proxy{
 			AvailableConnections: newPool,
 			HealthCheckPeriod:    config.DefaultHealthCheckPeriod,
@@ -55,7 +55,7 @@ func Test_Healthchecker(t *testing.T) {
 		})
 
 	pluginRegistry := plugin.NewRegistry(
-		context.TODO(),
+		context.Background(),
 		plugin.Registry{
 			ActRegistry:   actRegistry,
 			Compatibility: config.Loose,
@@ -75,7 +75,7 @@ func Test_Healthchecker(t *testing.T) {
 	}()
 
 	server := network.NewServer(
-		context.TODO(),
+		context.Background(),
 		network.Server{
 			Network:      config.DefaultNetwork,
 			Address:      "127.0.0.1:15432",
@@ -99,7 +99,7 @@ func Test_Healthchecker(t *testing.T) {
 		raftNode: raftHelper.Node,
 	}
 	assert.NotNil(t, healthchecker)
-	hcr, err := healthchecker.Check(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+	hcr, err := healthchecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, hcr)
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, hcr.GetStatus())
@@ -114,7 +114,7 @@ func Test_Healthchecker(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	// Test for SERVING status
-	hcr, err = healthchecker.Check(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+	hcr, err = healthchecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, hcr)
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, hcr.GetStatus())

--- a/api/http_server_test.go
+++ b/api/http_server_test.go
@@ -16,6 +16,7 @@ import (
 // Test_HTTP_Server tests the HTTP to gRPC gateway.
 func Test_HTTP_Server(t *testing.T) {
 	api := getAPIConfig()
+	api.Servers[config.Default].Address = ":0"
 	healthchecker := &HealthChecker{Servers: api.Servers}
 	grpcServer := NewGRPCServer(
 		context.Background(), GRPCServer{API: api, HealthChecker: healthchecker})

--- a/api/http_server_test.go
+++ b/api/http_server_test.go
@@ -85,6 +85,6 @@ func Test_HTTP_Server(t *testing.T) {
 	assert.Equal(t, len(config.Version), len(respBodyBytes))
 	assert.Equal(t, config.Version, string(respBodyBytes))
 
-	grpcServer.Shutdown(nil)
+	grpcServer.Shutdown(nil) //nolint:staticcheck
 	httpServer.Shutdown(context.Background())
 }

--- a/api/http_server_test.go
+++ b/api/http_server_test.go
@@ -85,6 +85,6 @@ func Test_HTTP_Server(t *testing.T) {
 	assert.Equal(t, len(config.Version), len(respBodyBytes))
 	assert.Equal(t, config.Version, string(respBodyBytes))
 
-	grpcServer.Shutdown(context.Background())
+	grpcServer.Shutdown(nil)
 	httpServer.Shutdown(context.Background())
 }

--- a/api/http_server_test.go
+++ b/api/http_server_test.go
@@ -15,30 +15,27 @@ import (
 
 // Test_HTTP_Server tests the HTTP to gRPC gateway.
 func Test_HTTP_Server(t *testing.T) {
-	api := getAPIConfig()
-	api.Servers[config.Default].Address = ":0"
+	api := getAPIConfig(
+		"localhost:18082",
+		"localhost:19092",
+	)
 	healthchecker := &HealthChecker{Servers: api.Servers}
 	grpcServer := NewGRPCServer(
 		context.Background(), GRPCServer{API: api, HealthChecker: healthchecker})
-	assert.NotNil(t, grpcServer)
+	go grpcServer.Start()
+	require.NotNil(t, grpcServer)
+
 	httpServer := NewHTTPServer(api.Options)
-	assert.NotNil(t, httpServer)
+	go httpServer.Start()
+	require.NotNil(t, httpServer)
 
-	go func(grpcServer *GRPCServer) {
-		grpcServer.Start()
-	}(grpcServer)
-
-	go func(httpServer *HTTPServer) {
-		httpServer.Start()
-	}(httpServer)
-
-	time.Sleep(1 * time.Second) // Wait for the servers to start.
+	time.Sleep(time.Second)
 
 	// Check version via the gRPC server.
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,
-		"http://localhost:18080/v1/GatewayDPluginService/Version",
+		"http://localhost:18082/v1/GatewayDPluginService/Version",
 		nil,
 	)
 	require.NoError(t, err)
@@ -57,7 +54,7 @@ func Test_HTTP_Server(t *testing.T) {
 	req, err = http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,
-		"http://localhost:18080/healthz",
+		"http://localhost:18082/healthz",
 		nil,
 	)
 	require.NoError(t, err)
@@ -74,7 +71,7 @@ func Test_HTTP_Server(t *testing.T) {
 	req, err = http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,
-		"http://localhost:18080/version",
+		"http://localhost:18082/version",
 		nil,
 	)
 	require.NoError(t, err)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -14,7 +14,7 @@ var configInitCmd = &cobra.Command{
 	Short: "Create or overwrite the GatewayD global config",
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Enable Sentry.
-		if enableSentry {
+		if App.EnableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -32,19 +32,21 @@ var configInitCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		generateConfig(cmd, Global, globalConfigFile, force)
+		generateConfig(cmd, Global, App.GlobalConfigFile, force)
 	},
 }
 
 func init() {
 	configCmd.AddCommand(configInitCmd)
 
+	App = &GatewayDInstance{}
+
 	configInitCmd.Flags().BoolVarP(
 		&force, "force", "f", false, "Force overwrite of existing config file")
 	configInitCmd.Flags().StringVarP(
-		&globalConfigFile, // Already exists in run.go
+		&App.GlobalConfigFile, // Already exists in run.go
 		"config", "c", config.GetDefaultConfigFilePath(config.GlobalConfigFilename),
 		"Global config file")
 	configInitCmd.Flags().BoolVar(
-		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -6,15 +6,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var force bool
-
 // configInitCmd represents the plugin init command.
 var configInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create or overwrite the GatewayD global config",
 	Run: func(cmd *cobra.Command, _ []string) {
+		force, _ := cmd.Flags().GetBool("force")
+		enableSentry, _ := cmd.Flags().GetBool("sentry")
+		globalConfigFile, _ := cmd.Flags().GetString("config")
+
 		// Enable Sentry.
-		if App.EnableSentry {
+		if enableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -32,21 +34,17 @@ var configInitCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		generateConfig(cmd, Global, App.GlobalConfigFile, force)
+		generateConfig(cmd, Global, globalConfigFile, force)
 	},
 }
 
 func init() {
 	configCmd.AddCommand(configInitCmd)
 
-	App = &GatewayDInstance{}
-
-	configInitCmd.Flags().BoolVarP(
-		&force, "force", "f", false, "Force overwrite of existing config file")
-	configInitCmd.Flags().StringVarP(
-		&App.GlobalConfigFile, // Already exists in run.go
+	configInitCmd.Flags().BoolP(
+		"force", "f", false, "Force overwrite of existing config file")
+	configInitCmd.Flags().StringP(
 		"config", "c", config.GetDefaultConfigFilePath(config.GlobalConfigFilename),
 		"Global config file")
-	configInitCmd.Flags().BoolVar(
-		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+	configInitCmd.Flags().Bool("sentry", true, "Enable Sentry")
 }

--- a/cmd/config_init_test.go
+++ b/cmd/config_init_test.go
@@ -15,21 +15,21 @@ func Test_configInitCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", App.GlobalConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 	// Check that the config file was created.
-	assert.FileExists(t, App.GlobalConfigFile, "configInitCmd should create a config file")
+	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
 	// Test configInitCmd with the --force flag to overwrite the config file.
 	output, err = executeCommandC(rootCmd, "config", "init", "--force", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was overwritten successfully.", App.GlobalConfigFile),
+		fmt.Sprintf("Config file '%s' was overwritten successfully.", globalTestConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 
 	// Clean up.
-	err = os.Remove(App.GlobalConfigFile)
+	err = os.Remove(globalTestConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/config_init_test.go
+++ b/cmd/config_init_test.go
@@ -15,21 +15,21 @@ func Test_configInitCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", App.GlobalConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 	// Check that the config file was created.
-	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
+	assert.FileExists(t, App.GlobalConfigFile, "configInitCmd should create a config file")
 
 	// Test configInitCmd with the --force flag to overwrite the config file.
 	output, err = executeCommandC(rootCmd, "config", "init", "--force", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was overwritten successfully.", globalTestConfigFile),
+		fmt.Sprintf("Config file '%s' was overwritten successfully.", App.GlobalConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 
 	// Clean up.
-	err = os.Remove(globalTestConfigFile)
+	err = os.Remove(App.GlobalConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/config_lint.go
+++ b/cmd/config_lint.go
@@ -14,8 +14,11 @@ var configLintCmd = &cobra.Command{
 	Use:   "lint",
 	Short: "Lint the GatewayD global config",
 	Run: func(cmd *cobra.Command, _ []string) {
+		enableSentry, _ := cmd.Flags().GetBool("sentry")
+		globalConfigFile, _ := cmd.Flags().GetString("config")
+
 		// Enable Sentry.
-		if App.EnableSentry {
+		if enableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -33,7 +36,7 @@ var configLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		if err := lintConfig(Global, App.GlobalConfigFile); err != nil {
+		if err := lintConfig(Global, globalConfigFile); err != nil {
 			log.Fatal(err)
 		}
 
@@ -44,12 +47,8 @@ var configLintCmd = &cobra.Command{
 func init() {
 	configCmd.AddCommand(configLintCmd)
 
-	App = &GatewayDInstance{}
-
-	configLintCmd.Flags().StringVarP(
-		&App.GlobalConfigFile, // Already exists in run.go
+	configLintCmd.Flags().StringP(
 		"config", "c", config.GetDefaultConfigFilePath(config.GlobalConfigFilename),
 		"Global config file")
-	configLintCmd.Flags().BoolVar(
-		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+	configLintCmd.Flags().Bool("sentry", true, "Enable Sentry")
 }

--- a/cmd/config_lint.go
+++ b/cmd/config_lint.go
@@ -15,7 +15,7 @@ var configLintCmd = &cobra.Command{
 	Short: "Lint the GatewayD global config",
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Enable Sentry.
-		if enableSentry {
+		if App.EnableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -33,7 +33,7 @@ var configLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		if err := lintConfig(Global, globalConfigFile); err != nil {
+		if err := lintConfig(Global, App.GlobalConfigFile); err != nil {
 			log.Fatal(err)
 		}
 
@@ -44,10 +44,12 @@ var configLintCmd = &cobra.Command{
 func init() {
 	configCmd.AddCommand(configLintCmd)
 
+	App = &GatewayDInstance{}
+
 	configLintCmd.Flags().StringVarP(
-		&globalConfigFile, // Already exists in run.go
+		&App.GlobalConfigFile, // Already exists in run.go
 		"config", "c", config.GetDefaultConfigFilePath(config.GlobalConfigFilename),
 		"Global config file")
 	configLintCmd.Flags().BoolVar(
-		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/config_lint_test.go
+++ b/cmd/config_lint_test.go
@@ -15,11 +15,11 @@ func Test_configLintCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", App.GlobalConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 	// Check that the config file was created.
-	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
+	assert.FileExists(t, App.GlobalConfigFile, "configInitCmd should create a config file")
 
 	// Test configLintCmd.
 	output, err = executeCommandC(rootCmd, "config", "lint", "-c", globalTestConfigFile)
@@ -30,6 +30,6 @@ func Test_configLintCmd(t *testing.T) {
 		"configLintCmd should print the correct output")
 
 	// Clean up.
-	err = os.Remove(globalTestConfigFile)
+	err = os.Remove(App.GlobalConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/config_lint_test.go
+++ b/cmd/config_lint_test.go
@@ -15,11 +15,11 @@ func Test_configLintCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "config", "init", "-c", globalTestConfigFile)
 	require.NoError(t, err, "configInitCmd should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", App.GlobalConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", globalTestConfigFile),
 		output,
 		"configInitCmd should print the correct output")
 	// Check that the config file was created.
-	assert.FileExists(t, App.GlobalConfigFile, "configInitCmd should create a config file")
+	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
 	// Test configLintCmd.
 	output, err = executeCommandC(rootCmd, "config", "lint", "-c", globalTestConfigFile)
@@ -30,6 +30,6 @@ func Test_configLintCmd(t *testing.T) {
 		"configLintCmd should print the correct output")
 
 	// Clean up.
-	err = os.Remove(App.GlobalConfigFile)
+	err = os.Remove(globalTestConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -27,7 +27,7 @@ func generateConfig(
 		GlobalKoanf: koanf.New("."),
 		PluginKoanf: koanf.New("."),
 	}
-	if err := conf.LoadDefaults(context.TODO()); err != nil {
+	if err := conf.LoadDefaults(context.Background()); err != nil {
 		logger.Fatal(err)
 	}
 
@@ -73,28 +73,28 @@ func lintConfig(fileType configFileType, configFile string) *gerr.GatewayDError 
 	var conf *config.Config
 	switch fileType {
 	case Global:
-		conf = config.NewConfig(context.TODO(), config.Config{GlobalConfigFile: configFile})
-		if err := conf.LoadDefaults(context.TODO()); err != nil {
+		conf = config.NewConfig(context.Background(), config.Config{GlobalConfigFile: configFile})
+		if err := conf.LoadDefaults(context.Background()); err != nil {
 			return err
 		}
-		if err := conf.LoadGlobalConfigFile(context.TODO()); err != nil {
+		if err := conf.LoadGlobalConfigFile(context.Background()); err != nil {
 			return err
 		}
-		if err := conf.ConvertKeysToLowercase(context.TODO()); err != nil {
+		if err := conf.ConvertKeysToLowercase(context.Background()); err != nil {
 			return err
 		}
-		if err := conf.UnmarshalGlobalConfig(context.TODO()); err != nil {
+		if err := conf.UnmarshalGlobalConfig(context.Background()); err != nil {
 			return err
 		}
 	case Plugins:
-		conf = config.NewConfig(context.TODO(), config.Config{PluginConfigFile: configFile})
-		if err := conf.LoadDefaults(context.TODO()); err != nil {
+		conf = config.NewConfig(context.Background(), config.Config{PluginConfigFile: configFile})
+		if err := conf.LoadDefaults(context.Background()); err != nil {
 			return err
 		}
-		if err := conf.LoadPluginConfigFile(context.TODO()); err != nil {
+		if err := conf.LoadPluginConfigFile(context.Background()); err != nil {
 			return err
 		}
-		if err := conf.UnmarshalPluginConfig(context.TODO()); err != nil {
+		if err := conf.UnmarshalPluginConfig(context.Background()); err != nil {
 			return err
 		}
 	default:

--- a/cmd/gatewayd_app.go
+++ b/cmd/gatewayd_app.go
@@ -1109,7 +1109,7 @@ func (app *GatewayDApp) stopGracefully(runCtx context.Context, sig os.Signal) {
 	}
 
 	if app.grpcServer != nil {
-		app.grpcServer.Shutdown(nil)
+		app.grpcServer.Shutdown(nil) //nolint:staticcheck,contextcheck
 		logger.Info().Msg("Stopped gRPC Server")
 		span.AddEvent("Stopped gRPC Server")
 	}

--- a/cmd/gatewayd_app.go
+++ b/cmd/gatewayd_app.go
@@ -1093,12 +1093,14 @@ func (app *GatewayDApp) stopGracefully(runCtx context.Context, sig os.Signal) {
 			earlyExit = true
 		}
 	}
+	logger.Info().Msg("Stopped all servers")
+	span.AddEvent("Stopped all servers")
+
 	if app.pluginRegistry != nil {
 		app.pluginRegistry.Shutdown()
 		logger.Info().Msg("Stopped plugin registry")
 		span.AddEvent("Stopped plugin registry")
 	}
-	span.End()
 
 	if app.httpServer != nil {
 		app.httpServer.Shutdown(runCtx)
@@ -1113,6 +1115,8 @@ func (app *GatewayDApp) stopGracefully(runCtx context.Context, sig os.Signal) {
 	}
 
 	logger.Info().Msg("GatewayD is shutdown")
+	span.AddEvent("GatewayD is shutdown")
+	span.End()
 
 	// If the code never reaches the point where the app.stopChan is used,
 	// it means that the server was never started. This is a manual shutdown

--- a/cmd/gatewayd_app.go
+++ b/cmd/gatewayd_app.go
@@ -1109,7 +1109,7 @@ func (app *GatewayDApp) stopGracefully(runCtx context.Context, sig os.Signal) {
 	}
 
 	if app.grpcServer != nil {
-		app.grpcServer.Shutdown(runCtx)
+		app.grpcServer.Shutdown(nil)
 		logger.Info().Msg("Stopped gRPC Server")
 		span.AddEvent("Stopped gRPC Server")
 	}

--- a/cmd/gatewayd_app.go
+++ b/cmd/gatewayd_app.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gatewayd-io/gatewayd/act"
 	"github.com/gatewayd-io/gatewayd/api"
 	"github.com/gatewayd-io/gatewayd/config"
-	gdErr "github.com/gatewayd-io/gatewayd/errors"
+	gerr "github.com/gatewayd-io/gatewayd/errors"
 	"github.com/gatewayd-io/gatewayd/logging"
 	"github.com/gatewayd-io/gatewayd/metrics"
 	"github.com/gatewayd-io/gatewayd/network"
@@ -1017,7 +1017,7 @@ func (app *GatewayDApp) startServers(
 				logger.Error().Err(err).Msg("Failed to start server")
 				span.RecordError(err)
 				app.stopGracefully(runCtx, nil)
-				os.Exit(gdErr.FailedToStartServer)
+				os.Exit(gerr.FailedToStartServer)
 			}
 		}(span, server, logger)
 	}

--- a/cmd/gatewayd_app.go
+++ b/cmd/gatewayd_app.go
@@ -1,0 +1,1071 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/NYTimes/gziphandler"
+	sdkAct "github.com/gatewayd-io/gatewayd-plugin-sdk/act"
+	sdkPlugin "github.com/gatewayd-io/gatewayd-plugin-sdk/plugin"
+	v1 "github.com/gatewayd-io/gatewayd-plugin-sdk/plugin/v1"
+	"github.com/gatewayd-io/gatewayd/act"
+	"github.com/gatewayd-io/gatewayd/api"
+	"github.com/gatewayd-io/gatewayd/config"
+	gdErr "github.com/gatewayd-io/gatewayd/errors"
+	"github.com/gatewayd-io/gatewayd/logging"
+	"github.com/gatewayd-io/gatewayd/metrics"
+	"github.com/gatewayd-io/gatewayd/network"
+	"github.com/gatewayd-io/gatewayd/plugin"
+	"github.com/gatewayd-io/gatewayd/pool"
+	"github.com/gatewayd-io/gatewayd/raft"
+	usage "github.com/gatewayd-io/gatewayd/usagereport/v1"
+	"github.com/getsentry/sentry-go"
+	"github.com/go-co-op/gocron"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type GatewayDApp struct {
+	EnableTracing     bool
+	EnableSentry      bool
+	EnableLinting     bool
+	EnableUsageReport bool
+	DevMode           bool
+	CollectorURL      string
+	PluginConfigFile  string
+	GlobalConfigFile  string
+
+	conf           *config.Config
+	pluginRegistry *plugin.Registry
+	actRegistry    *act.Registry
+	metricsServer  *http.Server
+	metricsMerger  *metrics.Merger
+	httpServer     *api.HTTPServer
+	grpcServer     *api.GRPCServer
+
+	loggers              map[string]zerolog.Logger
+	pools                map[string]map[string]*pool.Pool
+	clients              map[string]map[string]*config.Client
+	proxies              map[string]map[string]*network.Proxy
+	servers              map[string]*network.Server
+	healthCheckScheduler *gocron.Scheduler
+	stopChan             chan struct{}
+}
+
+// loadConfig loads global and plugin configuration.
+func (app *GatewayDApp) loadConfig(runCtx context.Context) error {
+	app.conf = config.NewConfig(runCtx,
+		config.Config{
+			GlobalConfigFile: app.GlobalConfigFile,
+			PluginConfigFile: app.PluginConfigFile,
+		},
+	)
+	if err := app.conf.InitConfig(runCtx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createLoggers creates loggers from the config.
+func (app *GatewayDApp) createLoggers(
+	runCtx context.Context, cmd *cobra.Command,
+) zerolog.Logger {
+	// Use cobra command cmd instead of os.Stdout for the console output.
+	cmdLogger := &cobraCmdWriter{cmd}
+
+	// Create a logger for each tenant.
+	for name, cfg := range app.conf.Global.Loggers {
+		app.loggers[name] = logging.NewLogger(runCtx, logging.LoggerConfig{
+			Output:     cfg.GetOutput(),
+			ConsoleOut: cmdLogger,
+			Level: config.If(
+				config.Exists(config.LogLevels, cfg.Level),
+				config.LogLevels[cfg.Level],
+				config.LogLevels[config.DefaultLogLevel],
+			),
+			TimeFormat: config.If(
+				config.Exists(config.TimeFormats, cfg.TimeFormat),
+				config.TimeFormats[cfg.TimeFormat],
+				config.TimeFormats[config.DefaultTimeFormat],
+			),
+			ConsoleTimeFormat: config.If(
+				config.Exists(
+					config.ConsoleTimeFormats, cfg.ConsoleTimeFormat),
+				config.ConsoleTimeFormats[cfg.ConsoleTimeFormat],
+				config.ConsoleTimeFormats[config.DefaultConsoleTimeFormat],
+			),
+			NoColor:        cfg.NoColor,
+			FileName:       cfg.FileName,
+			MaxSize:        cfg.MaxSize,
+			MaxBackups:     cfg.MaxBackups,
+			MaxAge:         cfg.MaxAge,
+			Compress:       cfg.Compress,
+			LocalTime:      cfg.LocalTime,
+			SyslogPriority: cfg.GetSyslogPriority(),
+			RSyslogNetwork: cfg.RSyslogNetwork,
+			RSyslogAddress: cfg.RSyslogAddress,
+			Name:           name,
+		})
+	}
+	return app.loggers[config.Default]
+}
+
+// createActRegistry creates a new act registry given
+// the built-in signals, policies, and actions.
+func (app *GatewayDApp) createActRegistry(logger zerolog.Logger) error {
+	// Create a new act registry given the built-in signals, policies, and actions.
+	var publisher *act.Publisher
+	if app.conf.Plugin.ActionRedis.Enabled {
+		rdb := redis.NewClient(&redis.Options{
+			Addr: app.conf.Plugin.ActionRedis.Address,
+		})
+		var err error
+		publisher, err = act.NewPublisher(act.Publisher{
+			Logger:      logger,
+			RedisDB:     rdb,
+			ChannelName: app.conf.Plugin.ActionRedis.Channel,
+		})
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to create publisher for act registry")
+			return err
+		}
+		logger.Info().Msg("Created Redis publisher for Act registry")
+	}
+
+	app.actRegistry = act.NewActRegistry(
+		act.Registry{
+			Signals:              act.BuiltinSignals(),
+			Policies:             act.BuiltinPolicies(),
+			Actions:              act.BuiltinActions(),
+			DefaultPolicyName:    app.conf.Plugin.DefaultPolicy,
+			PolicyTimeout:        app.conf.Plugin.PolicyTimeout,
+			DefaultActionTimeout: app.conf.Plugin.ActionTimeout,
+			TaskPublisher:        publisher,
+			Logger:               logger,
+		},
+	)
+
+	return nil
+}
+
+// loadPolicies loads policies from the configuration file and
+// adds them to the registry.
+func (app *GatewayDApp) loadPolicies(logger zerolog.Logger) error {
+	// Load policies from the configuration file and add them to the registry.
+	for _, plc := range app.conf.Plugin.Policies {
+		if policy, err := sdkAct.NewPolicy(
+			plc.Name, plc.Policy, plc.Metadata,
+		); err != nil || policy == nil {
+			logger.Error().Err(err).Str("name", plc.Name).Msg("Failed to create policy")
+			return err
+		} else {
+			app.actRegistry.Add(policy)
+		}
+	}
+
+	return nil
+}
+
+// createPluginRegistry creates a new plugin registry.
+func (app *GatewayDApp) createPluginRegistry(runCtx context.Context, logger zerolog.Logger) {
+	// Create a new plugin registry.
+	// The plugins are loaded and hooks registered before the configuration is loaded.
+	app.pluginRegistry = plugin.NewRegistry(
+		runCtx,
+		plugin.Registry{
+			ActRegistry: app.actRegistry,
+			Compatibility: config.If(
+				config.Exists(
+					config.CompatibilityPolicies, app.conf.Plugin.CompatibilityPolicy,
+				),
+				config.CompatibilityPolicies[app.conf.Plugin.CompatibilityPolicy],
+				config.DefaultCompatibilityPolicy),
+			Logger:  logger,
+			DevMode: app.DevMode,
+		},
+	)
+}
+
+// startMetricsMerger starts the metrics merger if enabled.
+func (app *GatewayDApp) startMetricsMerger(runCtx context.Context, logger zerolog.Logger) {
+	// Start the metrics merger if enabled.
+	if app.conf.Plugin.EnableMetricsMerger {
+		app.metricsMerger = metrics.NewMerger(runCtx, metrics.Merger{
+			MetricsMergerPeriod: app.conf.Plugin.MetricsMergerPeriod,
+			Logger:              logger,
+		})
+		app.pluginRegistry.ForEach(func(_ sdkPlugin.Identifier, plugin *plugin.Plugin) {
+			if metricsEnabled, err := strconv.ParseBool(plugin.Config["metricsEnabled"]); err == nil && metricsEnabled {
+				app.metricsMerger.Add(plugin.ID.Name, plugin.Config["metricsUnixDomainSocket"])
+				logger.Debug().Str("plugin", plugin.ID.Name).Msg(
+					"Added plugin to metrics merger")
+			}
+		})
+		app.metricsMerger.Start()
+	}
+}
+
+// startHealthCheckScheduler starts the health check scheduler if enabled.
+func (app *GatewayDApp) startHealthCheckScheduler(
+	runCtx, ctx context.Context, span trace.Span, logger zerolog.Logger,
+) {
+	// Ping the plugins to check if they are alive, and remove them if they are not.
+	startDelay := time.Now().Add(app.conf.Plugin.HealthCheckPeriod)
+	if _, err := app.healthCheckScheduler.Every(
+		app.conf.Plugin.HealthCheckPeriod).SingletonMode().StartAt(startDelay).Do(
+		func() {
+			_, span := otel.Tracer(config.TracerName).Start(ctx, "Run plugin health check")
+			defer span.End()
+
+			var plugins []string
+			app.pluginRegistry.ForEach(
+				func(pluginId sdkPlugin.Identifier, plugin *plugin.Plugin) {
+					if err := plugin.Ping(); err != nil {
+						span.RecordError(err)
+						logger.Error().Err(err).Msg("Failed to ping plugin")
+						if app.conf.Plugin.EnableMetricsMerger && app.metricsMerger != nil {
+							app.metricsMerger.Remove(pluginId.Name)
+						}
+						app.pluginRegistry.Remove(pluginId)
+
+						if !app.conf.Plugin.ReloadOnCrash {
+							return // Do not reload the plugins.
+						}
+
+						// Reload the plugins and register their hooks upon crash.
+						logger.Info().Str("name", pluginId.Name).Msg("Reloading crashed plugin")
+						pluginConfig := app.conf.Plugin.GetPlugins(pluginId.Name)
+						if pluginConfig != nil {
+							app.pluginRegistry.LoadPlugins(runCtx, pluginConfig, app.conf.Plugin.StartTimeout)
+						}
+					} else {
+						logger.Trace().Str("name", pluginId.Name).Msg("Successfully pinged plugin")
+						plugins = append(plugins, pluginId.Name)
+					}
+				})
+			span.SetAttributes(attribute.StringSlice("plugins", plugins))
+		}); err != nil {
+		logger.Error().Err(err).Msg("Failed to start plugin health check scheduler")
+		span.RecordError(err)
+	}
+
+	// Start the health check scheduler only if there are plugins.
+	if app.pluginRegistry.Size() > 0 {
+		logger.Info().Str(
+			"healthCheckPeriod", app.conf.Plugin.HealthCheckPeriod.String(),
+		).Msg("Starting plugin health check scheduler")
+		app.healthCheckScheduler.StartAsync()
+	}
+}
+
+// onConfigLoaded runs the OnConfigLoaded hook and
+// merges the global config with the one from the plugins.
+func (app *GatewayDApp) onConfigLoaded(
+	runCtx context.Context, span trace.Span, logger zerolog.Logger,
+) error {
+	// Set the plugin timeout context.
+	pluginTimeoutCtx, cancel := context.WithTimeout(
+		context.Background(), app.conf.Plugin.Timeout)
+	defer cancel()
+
+	// The config will be passed to the plugins that register to the "OnConfigLoaded" plugin.
+	// The plugins can modify the config and return it.
+	updatedGlobalConfig, err := app.pluginRegistry.Run(
+		pluginTimeoutCtx, app.conf.GlobalKoanf.All(), v1.HookName_HOOK_NAME_ON_CONFIG_LOADED)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to run OnConfigLoaded hooks")
+		span.RecordError(err)
+	}
+	if updatedGlobalConfig != nil {
+		updatedGlobalConfig = app.pluginRegistry.ActRegistry.RunAll(updatedGlobalConfig)
+	}
+
+	// If the config was modified by the plugins, merge it with the one loaded from the file.
+	// Only global configuration is merged, which means that plugins cannot modify the plugin
+	// configurations.
+	if updatedGlobalConfig != nil {
+		// Merge the config with the one loaded from the file (in memory).
+		// The changes won't be persisted to disk.
+		if err := app.conf.MergeGlobalConfig(runCtx, updatedGlobalConfig); err != nil {
+			logger.Error().Err(err).Msg("Failed to merge global config")
+			span.RecordError(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// startMetricsServer starts the metrics server if enabled.
+func (app *GatewayDApp) startMetricsServer(
+	runCtx context.Context, logger zerolog.Logger,
+) error {
+	// Start the metrics server if enabled.
+	// TODO: Start multiple metrics servers. For now, only one default is supported.
+	// I should first find a use case for those multiple metrics servers.
+	_, span := otel.Tracer(config.TracerName).Start(runCtx, "Start metrics server")
+	defer span.End()
+
+	metricsConfig := app.conf.Global.Metrics[config.Default]
+
+	// TODO: refactor this to a separate function.
+	if !metricsConfig.Enabled {
+		logger.Info().Msg("Metrics server is disabled")
+		return nil
+	}
+
+	scheme := "http://"
+	if metricsConfig.KeyFile != "" && metricsConfig.CertFile != "" {
+		scheme = "https://"
+	}
+
+	fqdn, err := url.Parse(scheme + metricsConfig.Address)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to parse metrics address")
+		span.RecordError(err)
+		return err
+	}
+
+	address, err := url.JoinPath(fqdn.String(), metricsConfig.Path)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to parse metrics path")
+		span.RecordError(err)
+		return err
+	}
+
+	// Merge the metrics from the plugins with the ones from GatewayD.
+	mergedMetricsHandler := func(next http.Handler) http.Handler {
+		handler := func(responseWriter http.ResponseWriter, request *http.Request) {
+			if _, err := responseWriter.Write(app.metricsMerger.OutputMetrics); err != nil {
+				logger.Error().Err(err).Msg("Failed to write metrics")
+				span.RecordError(err)
+				sentry.CaptureException(err)
+			}
+			// The WriteHeader method intentionally does nothing, to prevent a bug
+			// in the merging metrics that causes the headers to be written twice,
+			// which results in an error: "http: superfluous response.WriteHeader call".
+			next.ServeHTTP(
+				&metrics.HeaderBypassResponseWriter{
+					ResponseWriter: responseWriter,
+				},
+				request)
+		}
+		return http.HandlerFunc(handler)
+	}
+
+	handler := func() http.Handler {
+		return promhttp.InstrumentMetricHandler(
+			prometheus.DefaultRegisterer,
+			promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+				DisableCompression: true,
+			}),
+		)
+	}()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		// Serve a static page with a link to the metrics endpoint.
+		if _, err := responseWriter.Write([]byte(fmt.Sprintf(
+			`<html><head><title>GatewayD Prometheus Metrics Server</title></head><body><a href="%s">Metrics</a></body></html>`,
+			address,
+		))); err != nil {
+			logger.Error().Err(err).Msg("Failed to write metrics")
+			span.RecordError(err)
+			sentry.CaptureException(err)
+		}
+	})
+
+	if app.conf.Plugin.EnableMetricsMerger && app.metricsMerger != nil {
+		handler = mergedMetricsHandler(handler)
+	}
+
+	readHeaderTimeout := config.If(
+		metricsConfig.ReadHeaderTimeout > 0,
+		metricsConfig.ReadHeaderTimeout,
+		config.DefaultReadHeaderTimeout,
+	)
+
+	// Check if the metrics server is already running before registering the handler.
+	if _, err = http.Get(address); err != nil { //nolint:gosec
+		// The timeout handler limits the nested handlers from running for too long.
+		mux.Handle(
+			metricsConfig.Path,
+			http.TimeoutHandler(
+				gziphandler.GzipHandler(handler),
+				readHeaderTimeout,
+				"The request timed out while fetching the metrics",
+			),
+		)
+	} else {
+		logger.Warn().Msg("Metrics server is already running, consider changing the port")
+		span.RecordError(err)
+	}
+
+	// Create a new metrics server.
+	timeout := config.If(
+		metricsConfig.Timeout > 0,
+		metricsConfig.Timeout,
+		config.DefaultMetricsServerTimeout,
+	)
+	app.metricsServer = &http.Server{
+		Addr:              metricsConfig.Address,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       timeout,
+		WriteTimeout:      timeout,
+		IdleTimeout:       timeout,
+	}
+
+	logger.Info().Fields(map[string]any{
+		"address":           address,
+		"timeout":           timeout.String(),
+		"readHeaderTimeout": readHeaderTimeout.String(),
+	}).Msg("Metrics are exposed")
+
+	if metricsConfig.CertFile != "" && metricsConfig.KeyFile != "" {
+		// Set up TLS.
+		app.metricsServer.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			CurvePreferences: []tls.CurveID{
+				tls.CurveP521,
+				tls.CurveP384,
+				tls.CurveP256,
+			},
+			CipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+		}
+		app.metricsServer.TLSNextProto = make(
+			map[string]func(*http.Server, *tls.Conn, http.Handler))
+		logger.Debug().Msg("Metrics server is running with TLS")
+
+		// Start the metrics server with TLS.
+		if err = app.metricsServer.ListenAndServeTLS(
+			metricsConfig.CertFile, metricsConfig.KeyFile); !errors.Is(err, http.ErrServerClosed) {
+			logger.Error().Err(err).Msg("Failed to start metrics server")
+			span.RecordError(err)
+		}
+	} else {
+		// Start the metrics server without TLS.
+		if err = app.metricsServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			logger.Error().Err(err).Msg("Failed to start metrics server")
+			span.RecordError(err)
+		}
+	}
+
+	return nil
+}
+
+// onNewLogger runs the OnNewLogger hook.
+func (app *GatewayDApp) onNewLogger(
+	span trace.Span, logger zerolog.Logger,
+) {
+	// This is a notification hook, so we don't care about the result.
+	pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), app.conf.Plugin.Timeout)
+	defer cancel()
+
+	if data, ok := app.conf.GlobalKoanf.Get("loggers").(map[string]any); ok {
+		result, err := app.pluginRegistry.Run(
+			pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_LOGGER)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to run OnNewLogger hooks")
+			span.RecordError(err)
+		}
+		if result != nil {
+			_ = app.pluginRegistry.ActRegistry.RunAll(result)
+		}
+	} else {
+		logger.Error().Msg("Failed to get loggers from config")
+	}
+}
+
+// createPoolAndClients creates pools of connections and clients.
+func (app *GatewayDApp) createPoolAndClients(
+	runCtx context.Context, span trace.Span,
+) error {
+	// Create and initialize pools of connections.
+	for configGroupName, configGroup := range app.conf.Global.Pools {
+		for configBlockName, cfg := range configGroup {
+			logger := app.loggers[configGroupName]
+			// Check if the pool size is greater than zero.
+			currentPoolSize := config.If(
+				cfg.Size > 0,
+				// Check if the pool size is greater than the minimum pool size.
+				config.If(
+					cfg.Size > config.MinimumPoolSize,
+					cfg.Size,
+					config.MinimumPoolSize,
+				),
+				config.DefaultPoolSize,
+			)
+
+			if _, ok := app.pools[configGroupName]; !ok {
+				app.pools[configGroupName] = make(map[string]*pool.Pool)
+			}
+			app.pools[configGroupName][configBlockName] = pool.NewPool(runCtx, currentPoolSize)
+
+			span.AddEvent("Create pool", trace.WithAttributes(
+				attribute.String("name", configBlockName),
+				attribute.Int("size", currentPoolSize),
+			))
+
+			if _, ok := app.clients[configGroupName]; !ok {
+				app.clients[configGroupName] = make(map[string]*config.Client)
+			}
+
+			// Get client config from the config file.
+			if clientConfig, ok := app.conf.Global.Clients[configGroupName][configBlockName]; !ok {
+				// This ensures that the default client config is used if the pool name is not
+				// found in the clients section.
+				app.clients[configGroupName][configBlockName] = app.conf.Global.Clients[config.Default][config.DefaultConfigurationBlock] //nolint:lll
+			} else {
+				// Merge the default client config with the one from the pool.
+				app.clients[configGroupName][configBlockName] = clientConfig
+			}
+
+			// Fill the missing and zero values with the default ones.
+			app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod = config.If(
+				app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod > 0,
+				app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod,
+				config.DefaultTCPKeepAlivePeriod,
+			)
+			app.clients[configGroupName][configBlockName].ReceiveDeadline = config.If(
+				app.clients[configGroupName][configBlockName].ReceiveDeadline > 0,
+				app.clients[configGroupName][configBlockName].ReceiveDeadline,
+				config.DefaultReceiveDeadline,
+			)
+			app.clients[configGroupName][configBlockName].ReceiveTimeout = config.If(
+				app.clients[configGroupName][configBlockName].ReceiveTimeout > 0,
+				app.clients[configGroupName][configBlockName].ReceiveTimeout,
+				config.DefaultReceiveTimeout,
+			)
+			app.clients[configGroupName][configBlockName].SendDeadline = config.If(
+				app.clients[configGroupName][configBlockName].SendDeadline > 0,
+				app.clients[configGroupName][configBlockName].SendDeadline,
+				config.DefaultSendDeadline,
+			)
+			app.clients[configGroupName][configBlockName].ReceiveChunkSize = config.If(
+				app.clients[configGroupName][configBlockName].ReceiveChunkSize > 0,
+				app.clients[configGroupName][configBlockName].ReceiveChunkSize,
+				config.DefaultChunkSize,
+			)
+			app.clients[configGroupName][configBlockName].DialTimeout = config.If(
+				app.clients[configGroupName][configBlockName].DialTimeout > 0,
+				app.clients[configGroupName][configBlockName].DialTimeout,
+				config.DefaultDialTimeout,
+			)
+
+			// Add clients to the pool.
+			for range currentPoolSize {
+				clientConfig := app.clients[configGroupName][configBlockName]
+				clientConfig.GroupName = configGroupName
+				clientConfig.BlockName = configBlockName
+				client := network.NewClient(
+					runCtx, clientConfig, logger,
+					network.NewRetry(
+						network.Retry{
+							Retries: clientConfig.Retries,
+							Backoff: config.If(
+								clientConfig.Backoff > 0,
+								clientConfig.Backoff,
+								config.DefaultBackoff,
+							),
+							BackoffMultiplier:  clientConfig.BackoffMultiplier,
+							DisableBackoffCaps: clientConfig.DisableBackoffCaps,
+							Logger:             app.loggers[configBlockName],
+						},
+					),
+				)
+
+				if client == nil {
+					return errors.New("failed to create client, please check the configuration")
+				}
+
+				eventOptions := trace.WithAttributes(
+					attribute.String("name", configBlockName),
+					attribute.String("group", configGroupName),
+					attribute.String("network", client.Network),
+					attribute.String("address", client.Address),
+					attribute.Int("receiveChunkSize", client.ReceiveChunkSize),
+					attribute.String("receiveDeadline", client.ReceiveDeadline.String()),
+					attribute.String("receiveTimeout", client.ReceiveTimeout.String()),
+					attribute.String("sendDeadline", client.SendDeadline.String()),
+					attribute.String("dialTimeout", client.DialTimeout.String()),
+					attribute.Bool("tcpKeepAlive", client.TCPKeepAlive),
+					attribute.String("tcpKeepAlivePeriod", client.TCPKeepAlivePeriod.String()),
+					attribute.String("localAddress", client.LocalAddr()),
+					attribute.String("remoteAddress", client.RemoteAddr()),
+					attribute.Int("retries", clientConfig.Retries),
+					attribute.String("backoff", client.Retry().Backoff.String()),
+					attribute.Float64("backoffMultiplier", clientConfig.BackoffMultiplier),
+					attribute.Bool("disableBackoffCaps", clientConfig.DisableBackoffCaps),
+				)
+				if client.ID != "" {
+					eventOptions = trace.WithAttributes(
+						attribute.String("id", client.ID),
+					)
+				}
+
+				span.AddEvent("Create client", eventOptions)
+
+				pluginTimeoutCtx, cancel := context.WithTimeout(
+					context.Background(), app.conf.Plugin.Timeout)
+				defer cancel()
+
+				clientCfg := map[string]any{
+					"id":                 client.ID,
+					"name":               configBlockName,
+					"group":              configGroupName,
+					"network":            client.Network,
+					"address":            client.Address,
+					"receiveChunkSize":   client.ReceiveChunkSize,
+					"receiveDeadline":    client.ReceiveDeadline.String(),
+					"receiveTimeout":     client.ReceiveTimeout.String(),
+					"sendDeadline":       client.SendDeadline.String(),
+					"dialTimeout":        client.DialTimeout.String(),
+					"tcpKeepAlive":       client.TCPKeepAlive,
+					"tcpKeepAlivePeriod": client.TCPKeepAlivePeriod.String(),
+					"localAddress":       client.LocalAddr(),
+					"remoteAddress":      client.RemoteAddr(),
+					"retries":            clientConfig.Retries,
+					"backoff":            client.Retry().Backoff.String(),
+					"backoffMultiplier":  clientConfig.BackoffMultiplier,
+					"disableBackoffCaps": clientConfig.DisableBackoffCaps,
+				}
+				result, err := app.pluginRegistry.Run(
+					pluginTimeoutCtx, clientCfg, v1.HookName_HOOK_NAME_ON_NEW_CLIENT)
+				if err != nil {
+					logger.Error().Err(err).Msg("Failed to run OnNewClient hooks")
+					span.RecordError(err)
+				}
+				if result != nil {
+					_ = app.pluginRegistry.ActRegistry.RunAll(result)
+				}
+
+				err = app.pools[configGroupName][configBlockName].Put(client.ID, client)
+				if err != nil {
+					logger.Error().Err(err).Msg("Failed to add client to the pool")
+					span.RecordError(err)
+				}
+			}
+
+			// Verify that the pool is properly populated.
+			logger.Info().Fields(map[string]any{
+				"name":  configBlockName,
+				"count": strconv.Itoa(app.pools[configGroupName][configBlockName].Size()),
+			}).Msg("There are clients available in the pool")
+
+			if app.pools[configGroupName][configBlockName].Size() != currentPoolSize {
+				logger.Error().Msg(
+					"The pool size is incorrect, either because " +
+						"the clients cannot connect due to no network connectivity " +
+						"or the server is not running. exiting...")
+				app.pluginRegistry.Shutdown()
+				return errors.New("failed to initialize pool, please check the configuration")
+			}
+
+			// Run the OnNewPool hook.
+			pluginTimeoutCtx, cancel := context.WithTimeout(
+				context.Background(), app.conf.Plugin.Timeout)
+			defer cancel()
+
+			result, err := app.pluginRegistry.Run(
+				pluginTimeoutCtx,
+				map[string]any{"name": configBlockName, "size": currentPoolSize},
+				v1.HookName_HOOK_NAME_ON_NEW_POOL)
+			if err != nil {
+				logger.Error().Err(err).Msg("Failed to run OnNewPool hooks")
+				span.RecordError(err)
+			}
+			if result != nil {
+				_ = app.pluginRegistry.ActRegistry.RunAll(result)
+			}
+		}
+	}
+
+	return nil
+}
+
+// createProxies creates proxies.
+func (app *GatewayDApp) createProxies(runCtx context.Context, span trace.Span) {
+	// Create and initialize prefork proxies with each pool of clients.
+	for configGroupName, configGroup := range app.conf.Global.Proxies {
+		for configBlockName, cfg := range configGroup {
+			logger := app.loggers[configGroupName]
+			clientConfig := app.clients[configGroupName][configBlockName]
+
+			// Fill the missing and zero value with the default one.
+			cfg.HealthCheckPeriod = config.If(
+				cfg.HealthCheckPeriod > 0,
+				cfg.HealthCheckPeriod,
+				config.DefaultHealthCheckPeriod,
+			)
+
+			if _, ok := app.proxies[configGroupName]; !ok {
+				app.proxies[configGroupName] = make(map[string]*network.Proxy)
+			}
+
+			app.proxies[configGroupName][configBlockName] = network.NewProxy(
+				runCtx,
+				network.Proxy{
+					GroupName:            configGroupName,
+					BlockName:            configBlockName,
+					AvailableConnections: app.pools[configGroupName][configBlockName],
+					PluginRegistry:       app.pluginRegistry,
+					HealthCheckPeriod:    cfg.HealthCheckPeriod,
+					ClientConfig:         clientConfig,
+					Logger:               logger,
+					PluginTimeout:        app.conf.Plugin.Timeout,
+				},
+			)
+
+			span.AddEvent("Create proxy", trace.WithAttributes(
+				attribute.String("name", configBlockName),
+				attribute.String("healthCheckPeriod", cfg.HealthCheckPeriod.String()),
+			))
+
+			pluginTimeoutCtx, cancel := context.WithTimeout(
+				context.Background(), app.conf.Plugin.Timeout)
+			defer cancel()
+
+			if data, ok := app.conf.GlobalKoanf.Get("proxies").(map[string]any); ok {
+				result, err := app.pluginRegistry.Run(
+					pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_PROXY)
+				if err != nil {
+					logger.Error().Err(err).Msg("Failed to run OnNewProxy hooks")
+					span.RecordError(err)
+				}
+				if result != nil {
+					_ = app.pluginRegistry.ActRegistry.RunAll(result)
+				}
+			} else {
+				logger.Error().Msg("Failed to get proxy from config")
+			}
+		}
+	}
+}
+
+// createServers creates servers.
+func (app *GatewayDApp) createServers(
+	runCtx context.Context, span trace.Span, raftNode *raft.Node,
+) {
+	// Create and initialize servers.
+	for name, cfg := range app.conf.Global.Servers {
+		logger := app.loggers[name]
+
+		var serverProxies []network.IProxy
+		for _, proxy := range app.proxies[name] {
+			serverProxies = append(serverProxies, proxy)
+		}
+
+		app.servers[name] = network.NewServer(
+			runCtx,
+			network.Server{
+				GroupName: name,
+				Network:   cfg.Network,
+				Address:   cfg.Address,
+				TickInterval: config.If(
+					cfg.TickInterval > 0,
+					cfg.TickInterval,
+					config.DefaultTickInterval,
+				),
+				Options: network.Option{
+					// Can be used to send keepalive messages to the client.
+					EnableTicker: cfg.EnableTicker,
+				},
+				Proxies:                    serverProxies,
+				Logger:                     logger,
+				PluginRegistry:             app.pluginRegistry,
+				PluginTimeout:              app.conf.Plugin.Timeout,
+				EnableTLS:                  cfg.EnableTLS,
+				CertFile:                   cfg.CertFile,
+				KeyFile:                    cfg.KeyFile,
+				HandshakeTimeout:           cfg.HandshakeTimeout,
+				LoadbalancerStrategyName:   cfg.LoadBalancer.Strategy,
+				LoadbalancerRules:          cfg.LoadBalancer.LoadBalancingRules,
+				LoadbalancerConsistentHash: cfg.LoadBalancer.ConsistentHash,
+				RaftNode:                   raftNode,
+			},
+		)
+
+		span.AddEvent("Create server", trace.WithAttributes(
+			attribute.String("name", name),
+			attribute.String("network", cfg.Network),
+			attribute.String("address", cfg.Address),
+			attribute.String("tickInterval", cfg.TickInterval.String()),
+			attribute.String("pluginTimeout", app.conf.Plugin.Timeout.String()),
+			attribute.Bool("enableTLS", cfg.EnableTLS),
+			attribute.String("certFile", cfg.CertFile),
+			attribute.String("keyFile", cfg.KeyFile),
+			attribute.String("handshakeTimeout", cfg.HandshakeTimeout.String()),
+		))
+
+		pluginTimeoutCtx, cancel := context.WithTimeout(
+			context.Background(), app.conf.Plugin.Timeout)
+		defer cancel()
+
+		if data, ok := app.conf.GlobalKoanf.Get("servers").(map[string]any); ok {
+			result, err := app.pluginRegistry.Run(
+				pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_SERVER)
+			if err != nil {
+				logger.Error().Err(err).Msg("Failed to run OnNewServer hooks")
+				span.RecordError(err)
+			}
+			if result != nil {
+				_ = app.pluginRegistry.ActRegistry.RunAll(result)
+			}
+		} else {
+			logger.Error().Msg("Failed to get the servers configuration")
+		}
+	}
+}
+
+// startAPIServers starts the API servers.
+func (app *GatewayDApp) startAPIServers(
+	runCtx context.Context, logger zerolog.Logger, raftNode *raft.Node,
+) {
+	// Start the HTTP and gRPC APIs.
+	if !app.conf.Global.API.Enabled {
+		logger.Info().Msg("API is not enabled, skipping")
+		return
+	}
+
+	apiOptions := api.Options{
+		Logger:      logger,
+		GRPCNetwork: app.conf.Global.API.GRPCNetwork,
+		GRPCAddress: app.conf.Global.API.GRPCAddress,
+		HTTPAddress: app.conf.Global.API.HTTPAddress,
+		Servers:     app.servers,
+		RaftNode:    raftNode,
+	}
+
+	apiObj := &api.API{
+		Options:        &apiOptions,
+		Config:         app.conf,
+		PluginRegistry: app.pluginRegistry,
+		Pools:          app.pools,
+		Proxies:        app.proxies,
+		Servers:        app.servers,
+	}
+	app.grpcServer = api.NewGRPCServer(
+		runCtx,
+		api.GRPCServer{
+			API:           apiObj,
+			HealthChecker: &api.HealthChecker{Servers: app.servers},
+		},
+	)
+	if app.grpcServer != nil {
+		go app.grpcServer.Start()
+		logger.Info().Str("address", apiOptions.HTTPAddress).Msg("Started the HTTP API")
+
+		app.httpServer = api.NewHTTPServer(&apiOptions)
+		go app.httpServer.Start()
+
+		logger.Info().Fields(
+			map[string]any{
+				"network": apiOptions.GRPCNetwork,
+				"address": apiOptions.GRPCAddress,
+			},
+		).Msg("Started the gRPC Server")
+	}
+}
+
+// reportUsage reports usage statistics.
+func (app *GatewayDApp) reportUsage(logger zerolog.Logger) {
+	if !app.EnableUsageReport {
+		logger.Info().Msg("Usage reporting is not enabled, skipping")
+		return
+	}
+
+	// Report usage statistics.
+	go func() {
+		conn, err := grpc.NewClient(
+			UsageReportURL,
+			grpc.WithTransportCredentials(
+				credentials.NewTLS(
+					&tls.Config{
+						MinVersion: tls.VersionTLS12,
+					},
+				),
+			),
+		)
+		if err != nil {
+			logger.Trace().Err(err).Msg(
+				"Failed to dial to the gRPC server for usage reporting")
+		}
+		defer func(conn *grpc.ClientConn) {
+			err := conn.Close()
+			if err != nil {
+				logger.Trace().Err(err).Msg("Failed to close the connection to the usage report service")
+			}
+		}(conn)
+
+		client := usage.NewUsageReportServiceClient(conn)
+		report := usage.UsageReportRequest{
+			Version:        config.Version,
+			RuntimeVersion: runtime.Version(),
+			Goos:           runtime.GOOS,
+			Goarch:         runtime.GOARCH,
+			Service:        "gatewayd",
+			DevMode:        app.DevMode,
+			Plugins:        []*usage.Plugin{},
+		}
+		app.pluginRegistry.ForEach(
+			func(identifier sdkPlugin.Identifier, _ *plugin.Plugin) {
+				report.Plugins = append(report.GetPlugins(), &usage.Plugin{
+					Name:     identifier.Name,
+					Version:  identifier.Version,
+					Checksum: identifier.Checksum,
+				})
+			},
+		)
+		_, err = client.Report(context.Background(), &report)
+		if err != nil {
+			logger.Trace().Err(err).Msg("Failed to report usage statistics")
+		}
+	}()
+}
+
+// startServers starts the servers.
+func (app *GatewayDApp) startServers(
+	runCtx context.Context, span trace.Span,
+) {
+	// Start the server.
+	for name, server := range app.servers {
+		logger := app.loggers[name]
+		go func(
+			span trace.Span,
+			server *network.Server,
+			logger zerolog.Logger,
+			healthCheckScheduler *gocron.Scheduler,
+			metricsMerger *metrics.Merger,
+			pluginRegistry *plugin.Registry,
+		) {
+			span.AddEvent("Start server")
+			if err := server.Run(); err != nil {
+				logger.Error().Err(err).Msg("Failed to start server")
+				span.RecordError(err)
+				app.stopGracefully(runCtx, nil)
+				os.Exit(gdErr.FailedToStartServer)
+			}
+		}(span, server, logger, app.healthCheckScheduler, app.metricsMerger, app.pluginRegistry)
+	}
+}
+
+// stopGracefully stops the server gracefully.
+func (app *GatewayDApp) stopGracefully(runCtx context.Context, sig os.Signal) {
+	_, span := otel.Tracer(config.TracerName).Start(runCtx, "Shutdown server")
+	currentSignal := "unknown"
+	if sig != nil {
+		currentSignal = sig.String()
+	}
+
+	logger := app.loggers[config.Default]
+
+	logger.Info().Msg("Notifying the plugins that the server is shutting down")
+	if app.pluginRegistry != nil {
+		pluginTimeoutCtx, cancel := context.WithTimeout(
+			context.Background(), app.conf.Plugin.Timeout)
+		defer cancel()
+
+		//nolint:contextcheck
+		result, err := app.pluginRegistry.Run(
+			pluginTimeoutCtx,
+			map[string]any{"signal": currentSignal},
+			v1.HookName_HOOK_NAME_ON_SIGNAL,
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to run OnSignal hooks")
+			span.RecordError(err)
+		}
+		if result != nil {
+			_ = app.pluginRegistry.ActRegistry.RunAll(result) //nolint:contextcheck
+		}
+	}
+
+	logger.Info().Msg("GatewayD is shutting down")
+	span.AddEvent("GatewayD is shutting down", trace.WithAttributes(
+		attribute.String("signal", currentSignal),
+	))
+	if app.healthCheckScheduler != nil {
+		app.healthCheckScheduler.Stop()
+		app.healthCheckScheduler.Clear()
+		logger.Info().Msg("Stopped health check scheduler")
+		span.AddEvent("Stopped health check scheduler")
+	}
+	if app.metricsMerger != nil {
+		app.metricsMerger.Stop()
+		logger.Info().Msg("Stopped metrics merger")
+		span.AddEvent("Stopped metrics merger")
+	}
+	if app.metricsServer != nil {
+		//nolint:contextcheck
+		if err := app.metricsServer.Shutdown(context.Background()); err != nil {
+			logger.Error().Err(err).Msg("Failed to stop metrics server")
+			span.RecordError(err)
+		} else {
+			logger.Info().Msg("Stopped metrics server")
+			span.AddEvent("Stopped metrics server")
+		}
+	}
+	for name, server := range app.servers {
+		logger.Info().Str("name", name).Msg("Stopping server")
+		server.Shutdown()
+		span.AddEvent("Stopped server")
+	}
+	logger.Info().Msg("Stopped all servers")
+	if app.pluginRegistry != nil {
+		app.pluginRegistry.Shutdown()
+		logger.Info().Msg("Stopped plugin registry")
+		span.AddEvent("Stopped plugin registry")
+	}
+	span.End()
+
+	if app.httpServer != nil {
+		app.httpServer.Shutdown(runCtx)
+		logger.Info().Msg("Stopped HTTP Server")
+		span.AddEvent("Stopped HTTP Server")
+	}
+
+	if app.grpcServer != nil {
+		app.grpcServer.Shutdown(runCtx)
+		logger.Info().Msg("Stopped gRPC Server")
+		span.AddEvent("Stopped gRPC Server")
+	}
+
+	// Close the stop channel to notify the other goroutines to stop.
+	app.stopChan <- struct{}{}
+	close(app.stopChan)
+}
+
+// handleSignals handles the signals and stops the server gracefully.
+func (app *GatewayDApp) handleSignals(runCtx context.Context, signals []os.Signal) {
+	signalsCh := make(chan os.Signal, 1)
+	signal.Notify(signalsCh, signals...)
+
+	go func() {
+		for sig := range signalsCh {
+			app.stopGracefully(runCtx, sig)
+			os.Exit(0)
+		}
+	}()
+}

--- a/cmd/plugin_init.go
+++ b/cmd/plugin_init.go
@@ -12,7 +12,7 @@ var pluginInitCmd = &cobra.Command{
 	Short: "Create or overwrite the GatewayD plugins config",
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Enable Sentry.
-		if enableSentry {
+		if App.EnableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -30,19 +30,21 @@ var pluginInitCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		generateConfig(cmd, Plugins, pluginConfigFile, force)
+		generateConfig(cmd, Plugins, App.PluginConfigFile, force)
 	},
 }
 
 func init() {
 	pluginCmd.AddCommand(pluginInitCmd)
 
+	App = &GatewayDInstance{}
+
 	pluginInitCmd.Flags().BoolVarP(
 		&force, "force", "f", false, "Force overwrite of existing config file")
 	pluginInitCmd.Flags().StringVarP(
-		&pluginConfigFile, // Already exists in run.go
+		&App.PluginConfigFile, // Already exists in run.go
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
 	pluginInitCmd.Flags().BoolVar(
-		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/plugin_init.go
+++ b/cmd/plugin_init.go
@@ -11,8 +11,12 @@ var pluginInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create or overwrite the GatewayD plugins config",
 	Run: func(cmd *cobra.Command, _ []string) {
+		force, _ := cmd.Flags().GetBool("force")
+		enableSentry, _ := cmd.Flags().GetBool("sentry")
+		pluginConfigFile, _ := cmd.Flags().GetString("plugin-config")
+
 		// Enable Sentry.
-		if App.EnableSentry {
+		if enableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -30,21 +34,17 @@ var pluginInitCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		generateConfig(cmd, Plugins, App.PluginConfigFile, force)
+		generateConfig(cmd, Plugins, pluginConfigFile, force)
 	},
 }
 
 func init() {
 	pluginCmd.AddCommand(pluginInitCmd)
 
-	App = &GatewayDInstance{}
-
-	pluginInitCmd.Flags().BoolVarP(
-		&force, "force", "f", false, "Force overwrite of existing config file")
-	pluginInitCmd.Flags().StringVarP(
-		&App.PluginConfigFile, // Already exists in run.go
+	pluginInitCmd.Flags().BoolP(
+		"force", "f", false, "Force overwrite of existing config file")
+	pluginInitCmd.Flags().StringP(
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
-	pluginInitCmd.Flags().BoolVar(
-		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+	pluginInitCmd.Flags().Bool("sentry", true, "Enable Sentry")
 }

--- a/cmd/plugin_init_test.go
+++ b/cmd/plugin_init_test.go
@@ -15,13 +15,13 @@ func Test_pluginInitCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", App.PluginConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
 		output,
 		"plugin init command should have returned the correct output")
 	assert.FileExists(
-		t, App.PluginConfigFile, "plugin init command should have created a config file")
+		t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	// Clean up.
-	err = os.Remove(App.PluginConfigFile)
+	err = os.Remove(pluginTestConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/plugin_init_test.go
+++ b/cmd/plugin_init_test.go
@@ -15,12 +15,13 @@ func Test_pluginInitCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", App.PluginConfigFile),
 		output,
 		"plugin init command should have returned the correct output")
-	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
+	assert.FileExists(
+		t, App.PluginConfigFile, "plugin init command should have created a config file")
 
 	// Clean up.
-	err = os.Remove(pluginTestConfigFile)
+	err = os.Remove(App.PluginConfigFile)
 	assert.Nil(t, err)
 }

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -615,12 +615,6 @@ func installPlugin(
 			cmd.Println("Plugin name not specified")
 			return
 		}
-
-		// If pullOnly is true, we're done after verifying the file exists
-		if pullOnly {
-			cmd.Println("Plugin file verified at", pluginFilename)
-			return
-		}
 	case SourceGitHub:
 		// Strip scheme from the plugin URL.
 		pluginURL = strings.TrimPrefix(strings.TrimPrefix(pluginURL, "http://"), "https://")

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -121,16 +121,6 @@ var pluginInstallCmd = &cobra.Command{
 				return
 			}
 
-			// Backup the config file if requested
-			if backupConfig {
-				backupFilename := pluginConfigFile + BackupFileExt
-				if err := os.WriteFile(backupFilename, pluginsConfig, FilePermissions); err != nil {
-					cmd.Println("There was an error backing up the plugins configuration file: ", err)
-					return
-				}
-				cmd.Println("Backup completed successfully")
-			}
-
 			// Get the registered plugins from the plugins configuration file.
 			var localPluginsConfig map[string]any
 			if err := yamlv3.Unmarshal(pluginsConfig, &localPluginsConfig); err != nil {

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -572,7 +572,7 @@ func getFileExtension() Extension {
 func installPlugin(
 	cmd *cobra.Command,
 	pluginURL string,
-	outputDir string,
+	pluginOutputDir string,
 	pullOnly bool,
 	cleanup bool,
 	noPrompt bool,
@@ -686,7 +686,7 @@ func installPlugin(
 		}
 
 		// Create the output directory if it doesn't exist.
-		if err := os.MkdirAll(outputDir, FolderPermissions); err != nil {
+		if err := os.MkdirAll(pluginOutputDir, FolderPermissions); err != nil {
 			cmd.Println("There was an error creating the output directory: ", err)
 			return
 		}
@@ -700,7 +700,7 @@ func installPlugin(
 		if downloadURL != "" && releaseID != 0 {
 			cmd.Println("Downloading", downloadURL)
 			filePath, gErr := downloadFile(
-				client, account, pluginName, releaseID, pluginFilename, outputDir)
+				client, account, pluginName, releaseID, pluginFilename, pluginOutputDir)
 			toBeDeleted = append(toBeDeleted, filePath)
 			if gErr != nil {
 				cmd.Println("Download failed: ", gErr)
@@ -723,7 +723,7 @@ func installPlugin(
 		if checksumsFilename != "" && downloadURL != "" && releaseID != 0 {
 			cmd.Println("Downloading", downloadURL)
 			filePath, gErr := downloadFile(
-				client, account, pluginName, releaseID, checksumsFilename, outputDir)
+				client, account, pluginName, releaseID, checksumsFilename, pluginOutputDir)
 			toBeDeleted = append(toBeDeleted, filePath)
 			if gErr != nil {
 				cmd.Println("Download failed: ", gErr)
@@ -860,9 +860,9 @@ func installPlugin(
 	var gErr *gerr.GatewayDError
 	switch archiveExt {
 	case ExtensionZip:
-		filenames, gErr = extractZip(pluginFilename, outputDir, skipPathSlipVerification)
+		filenames, gErr = extractZip(pluginFilename, pluginOutputDir, skipPathSlipVerification)
 	case ExtensionTarGz:
-		filenames, gErr = extractTarGz(pluginFilename, outputDir, skipPathSlipVerification)
+		filenames, gErr = extractTarGz(pluginFilename, pluginOutputDir, skipPathSlipVerification)
 	default:
 		cmd.Println("Invalid archive extension")
 		return
@@ -925,7 +925,7 @@ func installPlugin(
 	} else {
 		// Get the contents of the file.
 		contentsBytes, err := os.ReadFile(
-			filepath.Join(outputDir, DefaultPluginConfigFilename))
+			filepath.Join(pluginOutputDir, DefaultPluginConfigFilename))
 		if err != nil {
 			cmd.Println(
 				"There was an error getting the default plugins configuration file: ", err)

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -770,11 +770,9 @@ func installPlugin(
 
 		if pullOnly {
 			cmd.Println("Plugin binary downloaded to", pluginFilename)
-			// Only delete the checksums file if the --pull-only flag is set
-			if cleanup {
-				if err := os.Remove(checksumsFilename); err != nil {
-					cmd.Println("There was an error deleting the checksums file: ", err)
-				}
+			// Only the checksums file will be deleted if the --pull-only flag is set.
+			if err := os.Remove(checksumsFilename); err != nil {
+				cmd.Println("There was an error deleting the file: ", err)
 			}
 			return
 		}

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -47,7 +47,7 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
 	// Clean up.
-	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
+	assert.FileExists(t, filepath.Join("./plugins", "gatewayd-plugin-cache"))
 	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz")
 	assert.NoFileExists(t, "checksums.txt")
@@ -83,7 +83,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	assert.Contains(t, output, "Plugin installed successfully")
 
 	// Clean up.
-	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
+	assert.FileExists(t, filepath.Join("./plugins", "gatewayd-plugin-cache"))
 	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "plugins/LICENSE")
 	assert.NoFileExists(t, "plugins/README.md")

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -12,6 +12,8 @@ import (
 
 func Test_pluginInstallCmd(t *testing.T) {
 	pluginTestConfigFile := "./test_plugins_pluginInstallCmd.yaml"
+	// TODO: hack
+	App.PluginConfigFile = pluginTestConfigFile
 
 	// Create a test plugin config file.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -47,7 +47,7 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
 	// Clean up.
-	assert.FileExists(t, filepath.Join("./plugins", "gatewayd-plugin-cache"))
+	assert.FileExists(t, "./plugins/gatewayd-plugin-cache")
 	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz")
 	assert.NoFileExists(t, "checksums.txt")
@@ -83,7 +83,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	assert.Contains(t, output, "Plugin installed successfully")
 
 	// Clean up.
-	assert.FileExists(t, filepath.Join("./plugins", "gatewayd-plugin-cache"))
+	assert.FileExists(t, "./plugins/gatewayd-plugin-cache")
 	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "plugins/LICENSE")
 	assert.NoFileExists(t, "plugins/README.md")

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -73,11 +73,11 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 		"--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
+	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz") //nolint:lll
 	assert.Contains(t, output, "File downloaded to "+pluginArchivePath)
 	assert.Contains(t, output, "Download completed successfully")
-	assert.Contains(t, output, "checksums.txt")
-	assert.Contains(t, output, "Checksum verification passed")
-	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
+	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/checksums.txt") //nolint:lll
+	assert.Contains(t, output, "Plugin binary downloaded to gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz")
 	assert.Contains(t, output, "Plugin installed successfully")
 
 	// See if the plugin was actually installed.

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -69,7 +69,8 @@ func Test_pluginInstallCmdAutomated(t *testing.T) {
 
 	// Test plugin install command.
 	output, err := executeCommandC(
-		rootCmd, "plugin", "install", "-p", pluginTestConfigFile)
+		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
+		"--update", "--backup")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz") //nolint:lll
@@ -96,4 +97,7 @@ func Test_pluginInstallCmdAutomated(t *testing.T) {
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
+	require.NoError(t, os.Remove(pluginArchivePath))
+	require.NoError(t, os.Remove(filepath.Join(pwd, "checksums.txt")))
+	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -57,6 +57,8 @@ func Test_pluginInstallCmd(t *testing.T) {
 
 func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
+	// TODO: This test should be removed once the plugin install command is refactored.
+	App.PluginConfigFile = pluginTestConfigFile
 
 	// Reset the global variable.
 	pullOnly = false

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -77,7 +77,11 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	assert.Contains(t, output, "File downloaded to "+pluginArchivePath)
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/checksums.txt") //nolint:lll
-	assert.Contains(t, output, "Plugin binary downloaded to gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz")
+	assert.Contains(t, output, "File downloaded to "+filepath.Join(pwd, "checksums.txt"))
+	assert.Contains(t, output, "Download completed successfully")
+	assert.Contains(t, output, "Checksum verification passed")
+	assert.Contains(t, output, "Backup completed successfully")
+	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
 	assert.Contains(t, output, "Plugin installed successfully")
 
 	// See if the plugin was actually installed.

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_pluginInstallCmd(t *testing.T) {
-	pluginTestConfigFile := "./test_plugins_pluginInstallCmd.yaml"
+func Test_pluginInstallCmdWithFile(t *testing.T) {
+	pluginTestConfigFile := "./test_plugins_pluginInstallCmdWithFile.yaml"
 
 	// Create a test plugin config file.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
@@ -34,10 +34,10 @@ func Test_pluginInstallCmd(t *testing.T) {
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
 		"--update", "--backup", "--name=gatewayd-plugin-cache", pluginArchivePath)
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Equal(t,
-		"Installing plugin from CLI argument\nBackup completed successfully\nPlugin binary extracted to plugins/gatewayd-plugin-cache\nPlugin installed successfully\n", //nolint:lll
-		output,
-	)
+	assert.Contains(t, output, "Installing plugin from CLI argument")
+	assert.Contains(t, output, "Backup completed successfully")
+	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
+	assert.Contains(t, output, "Plugin installed successfully")
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
@@ -60,7 +60,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }
 
-func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
+func Test_pluginInstallCmdAutomated(t *testing.T) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "os.Getwd should not return an error")
 	pluginArchivePath := filepath.Join(pwd, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-v0.4.0.tar.gz", runtime.GOOS, runtime.GOARCH)) //nolint:lll
@@ -69,9 +69,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 
 	// Test plugin install command.
 	output, err := executeCommandC(
-		rootCmd, "plugin", "install",
-		"-p", pluginTestConfigFile,
-		"--update", "--backup", "--overwrite-config=false", "--skip-path-slip-verification")
+		rootCmd, "plugin", "install", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz") //nolint:lll

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -55,6 +55,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
+	require.NoError(t, os.Remove(pluginArchivePath))
 	require.NoError(t, os.Remove(pluginTestConfigFile))
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -62,9 +62,6 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 }
 
 func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
-	pwd, err := os.Getwd()
-	require.NoError(t, err, "os.Getwd should not return an error")
-
 	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
 
 	// Test plugin install command with overwrite disabled
@@ -75,19 +72,25 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 
 	// Verify expected output for no-overwrite case
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
-	assert.Contains(t, output, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
+	assert.Contains(
+		t,
+		output,
+		fmt.Sprintf("gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
 	assert.Contains(t, output, "checksums.txt")
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")
 	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
 	assert.Contains(t, output, "Plugin installed successfully")
 
-	// Cleanup
+	// Clean up.
+	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
+	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
+	assert.NoFileExists(t, "plugins/LICENSE")
+	assert.NoFileExists(t, "plugins/README.md")
+	assert.NoFileExists(t, "plugins/checksum.txt")
+	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
+
 	require.NoError(t, os.RemoveAll("plugins/"))
-	checksumFile := filepath.Join(pwd, "checksums.txt")
-	if _, err := os.Stat(checksumFile); err == nil {
-		require.NoError(t, os.Remove(checksumFile))
-	}
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }
 

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -71,7 +71,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install",
 		"-p", pluginTestConfigFile,
-		"--update", "--backup", "--overwrite-config=false")
+		"--update", "--backup", "--overwrite-config=false", "--skip-path-slip-verification")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
 	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz") //nolint:lll

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -25,6 +25,7 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 		t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	// Pull the plugin archive and install it.
+	var pluginArchivePath string
 	pluginArchivePath, err = mustPullPlugin()
 	require.NoError(t, err, "mustPullPlugin should not return an error")
 	assert.FileExists(t, pluginArchivePath, "mustPullPlugin should have downloaded the plugin archive")

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -60,44 +60,67 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }
 
-func Test_pluginInstallCmdAutomated(t *testing.T) {
+func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "os.Getwd should not return an error")
-	pluginArchivePath := filepath.Join(pwd, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-v0.4.0.tar.gz", runtime.GOOS, runtime.GOARCH)) //nolint:lll
 
 	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
 
-	// Test plugin install command.
+	// Test plugin install command with overwrite disabled
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
-		"--update", "--backup")
+		"--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
+
+	// Verify expected output for no-overwrite case
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/gatewayd-plugin-cache-linux-amd64-v0.4.0.tar.gz") //nolint:lll
-	assert.Contains(t, output, "File downloaded to "+pluginArchivePath)
-	assert.Contains(t, output, "Download completed successfully")
-	assert.Contains(t, output, "Downloading https://github.com/gatewayd-io/gatewayd-plugin-cache/releases/download/v0.4.0/checksums.txt") //nolint:lll
-	assert.Contains(t, output, "File downloaded to "+filepath.Join(pwd, "checksums.txt"))
+	assert.Contains(t, output, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
+	assert.Contains(t, output, "checksums.txt")
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")
 	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
 	assert.Contains(t, output, "Plugin installed successfully")
 
-	// See if the plugin was actually installed.
-	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
-	require.NoError(t, err, "plugin list should not return an error")
-	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
-
-	// Clean up.
-	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
-	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
-	assert.NoFileExists(t, "plugins/LICENSE")
-	assert.NoFileExists(t, "plugins/README.md")
-	assert.NoFileExists(t, "plugins/checksum.txt")
-	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
-
+	// Cleanup
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginArchivePath))
-	require.NoError(t, os.Remove(filepath.Join(pwd, "checksums.txt")))
+	checksumFile := filepath.Join(pwd, "checksums.txt")
+	if _, err := os.Stat(checksumFile); err == nil {
+		require.NoError(t, os.Remove(checksumFile))
+	}
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
+}
+
+func Test_pluginInstallCmdPullOnly(t *testing.T) {
+	pwd, err := os.Getwd()
+	require.NoError(t, err, "os.Getwd should not return an error")
+
+	pluginTestConfigFile := "./testdata/gatewayd_plugins.yaml"
+
+	// Test plugin install command in pull-only mode
+	output, err := executeCommandC(
+		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
+		"--update", "--backup", "--pull-only", "--overwrite-config=false")
+	require.NoError(t, err, "plugin install should not return an error")
+
+	// Verify pull-only behavior
+	assert.Contains(t, output, "Installing plugins from plugins configuration file")
+	assert.Contains(t, output, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
+	assert.Contains(t, output, "Download completed successfully")
+
+	// Should not contain installation messages in pull-only mode
+	assert.NotContains(t, output, "Plugin binary extracted")
+	assert.NotContains(t, output, "Plugin installed successfully")
+
+	// Cleanup downloaded files
+	pattern := filepath.Join(pwd, fmt.Sprintf("gatewayd-plugin-cache-%s-%s-*.tar.gz", runtime.GOOS, runtime.GOARCH))
+	matches, err := filepath.Glob(pattern)
+	require.NoError(t, err, "failed to glob plugin archives")
+	for _, match := range matches {
+		require.NoError(t, os.Remove(match))
+	}
+
+	checksumFile := filepath.Join(pwd, "checksums.txt")
+	if _, err := os.Stat(checksumFile); err == nil {
+		require.NoError(t, os.Remove(checksumFile))
+	}
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -79,7 +79,6 @@ func Test_pluginInstallCmdAutomated(t *testing.T) {
 	assert.Contains(t, output, "File downloaded to "+filepath.Join(pwd, "checksums.txt"))
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")
-	assert.Contains(t, output, "Backup completed successfully")
 	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
 	assert.Contains(t, output, "Plugin installed successfully")
 
@@ -97,5 +96,4 @@ func Test_pluginInstallCmdAutomated(t *testing.T) {
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -17,10 +17,11 @@ func Test_pluginInstallCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init should not return an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", App.PluginConfigFile),
 		output,
 		"plugin init command should have returned the correct output")
-	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
+	assert.FileExists(
+		t, App.PluginConfigFile, "plugin init command should have created a config file")
 
 	// Pull the plugin archive and install it.
 	pluginArchivePath, err = mustPullPlugin()
@@ -41,7 +42,7 @@ func Test_pluginInstallCmd(t *testing.T) {
 
 	// Clean up.
 	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
-	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
+	assert.FileExists(t, App.PluginConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "gatewayd-plugin-cache-linux-amd64-v0.2.4.tar.gz")
 	assert.NoFileExists(t, "checksums.txt")
 	assert.NoFileExists(t, "plugins/LICENSE")
@@ -50,8 +51,8 @@ func Test_pluginInstallCmd(t *testing.T) {
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginTestConfigFile))
-	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
+	require.NoError(t, os.Remove(App.PluginConfigFile))
+	require.NoError(t, os.Remove(App.PluginConfigFile+BackupFileExt))
 }
 
 func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
@@ -65,7 +66,8 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 		rootCmd, "plugin", "install",
 		"-p", pluginTestConfigFile, "--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Contains(t, output, fmt.Sprintf("/gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
+	assert.Contains(
+		t, output, fmt.Sprintf("/gatewayd-plugin-cache-%s-%s-", runtime.GOOS, runtime.GOARCH))
 	assert.Contains(t, output, "/checksums.txt")
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "Checksum verification passed")
@@ -79,12 +81,12 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 
 	// Clean up.
 	assert.FileExists(t, "plugins/gatewayd-plugin-cache")
-	assert.FileExists(t, pluginTestConfigFile+BackupFileExt)
+	assert.FileExists(t, App.PluginConfigFile+BackupFileExt)
 	assert.NoFileExists(t, "plugins/LICENSE")
 	assert.NoFileExists(t, "plugins/README.md")
 	assert.NoFileExists(t, "plugins/checksum.txt")
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
+	require.NoError(t, os.Remove(App.PluginConfigFile+BackupFileExt))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -73,7 +73,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 		"--update", "--backup", "--overwrite-config=false")
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugins from plugins configuration file")
-	assert.Contains(t, output, fmt.Sprintf("File downloaded to %s", pluginArchivePath))
+	assert.Contains(t, output, "File downloaded to "+pluginArchivePath)
 	assert.Contains(t, output, "Download completed successfully")
 	assert.Contains(t, output, "checksums.txt")
 	assert.Contains(t, output, "Checksum verification passed")

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -15,7 +15,8 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	pluginTestConfigFile := "./test_plugins_pluginInstallCmdWithFile.yaml"
 
 	// Create a test plugin config file.
-	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
+	output, err := executeCommandC(
+		rootCmd, "plugin", "init", "-p", pluginTestConfigFile, "--force")
 	require.NoError(t, err, "plugin init should not return an error")
 	assert.Equal(t,
 		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
@@ -33,7 +34,7 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	// Test plugin install command.
 	output, err = executeCommandC(
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
-		"--update", "--backup", "--name=gatewayd-plugin-cache", pluginArchivePath)
+		"--backup", "--name=gatewayd-plugin-cache", pluginArchivePath)
 	require.NoError(t, err, "plugin install should not return an error")
 	assert.Contains(t, output, "Installing plugin from CLI argument")
 	assert.Contains(t, output, "Backup completed successfully")
@@ -56,7 +57,6 @@ func Test_pluginInstallCmdWithFile(t *testing.T) {
 	assert.NoFileExists(t, "plugins/gatewayd_plugin.yaml")
 
 	require.NoError(t, os.RemoveAll("plugins/"))
-	require.NoError(t, os.Remove(pluginArchivePath))
 	require.NoError(t, os.Remove(pluginTestConfigFile))
 	require.NoError(t, os.Remove(pluginTestConfigFile+BackupFileExt))
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -67,7 +67,7 @@ func Test_pluginInstallCmdAutomatedNoOverwrite(t *testing.T) {
 	// Test plugin install command with overwrite disabled
 	output, err := executeCommandC(
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile,
-		"--update", "--backup", "--overwrite-config=false")
+		"--update", "--backup", "--overwrite-config=false", "--pull-only=false")
 	require.NoError(t, err, "plugin install should not return an error")
 
 	// Verify expected output for no-overwrite case

--- a/cmd/plugin_lint.go
+++ b/cmd/plugin_lint.go
@@ -14,8 +14,11 @@ var pluginLintCmd = &cobra.Command{
 	Use:   "lint",
 	Short: "Lint the GatewayD plugins config",
 	Run: func(cmd *cobra.Command, _ []string) {
+		enableSentry, _ := cmd.Flags().GetBool("sentry")
+		pluginConfigFile, _ := cmd.Flags().GetString("plugin-config")
+
 		// Enable Sentry.
-		if App.EnableSentry {
+		if enableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -33,7 +36,7 @@ var pluginLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		if err := lintConfig(Plugins, App.PluginConfigFile); err != nil {
+		if err := lintConfig(Plugins, pluginConfigFile); err != nil {
 			log.Fatal(err)
 		}
 
@@ -44,12 +47,9 @@ var pluginLintCmd = &cobra.Command{
 func init() {
 	pluginCmd.AddCommand(pluginLintCmd)
 
-	App = &GatewayDInstance{}
-
-	pluginLintCmd.Flags().StringVarP(
-		&App.PluginConfigFile, // Already exists in run.go
+	pluginLintCmd.Flags().StringP(
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
-	pluginLintCmd.Flags().BoolVar(
-		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+	pluginLintCmd.Flags().BoolP(
+		"sentry", "s", true, "Enable Sentry")
 }

--- a/cmd/plugin_lint.go
+++ b/cmd/plugin_lint.go
@@ -15,7 +15,7 @@ var pluginLintCmd = &cobra.Command{
 	Short: "Lint the GatewayD plugins config",
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Enable Sentry.
-		if enableSentry {
+		if App.EnableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -33,7 +33,7 @@ var pluginLintCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		if err := lintConfig(Plugins, pluginConfigFile); err != nil {
+		if err := lintConfig(Plugins, App.PluginConfigFile); err != nil {
 			log.Fatal(err)
 		}
 
@@ -44,10 +44,12 @@ var pluginLintCmd = &cobra.Command{
 func init() {
 	pluginCmd.AddCommand(pluginLintCmd)
 
+	App = &GatewayDInstance{}
+
 	pluginLintCmd.Flags().StringVarP(
-		&pluginConfigFile, // Already exists in run.go
+		&App.PluginConfigFile, // Already exists in run.go
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
 	pluginLintCmd.Flags().BoolVar(
-		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }

--- a/cmd/plugin_list.go
+++ b/cmd/plugin_list.go
@@ -17,7 +17,7 @@ var pluginListCmd = &cobra.Command{
 	Short: "List the GatewayD plugins",
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Enable Sentry.
-		if enableSentry {
+		if App.EnableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -35,15 +35,17 @@ var pluginListCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		listPlugins(cmd, pluginConfigFile, onlyEnabled)
+		listPlugins(cmd, App.PluginConfigFile, onlyEnabled)
 	},
 }
 
 func init() {
 	pluginCmd.AddCommand(pluginListCmd)
 
+	App = &GatewayDInstance{}
+
 	pluginListCmd.Flags().StringVarP(
-		&pluginConfigFile, // Already exists in run.go
+		&App.PluginConfigFile, // Already exists in run.go
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
 	pluginListCmd.Flags().BoolVarP(
@@ -51,7 +53,7 @@ func init() {
 		"only-enabled", "e",
 		false, "Only list enabled plugins")
 	pluginListCmd.Flags().BoolVar(
-		&enableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
 }
 
 func listPlugins(cmd *cobra.Command, pluginConfigFile string, onlyEnabled bool) {

--- a/cmd/plugin_list.go
+++ b/cmd/plugin_list.go
@@ -9,14 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var onlyEnabled bool
-
 // pluginListCmd represents the plugin list command.
 var pluginListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the GatewayD plugins",
 	Run: func(cmd *cobra.Command, _ []string) {
 		pluginConfigFile, _ := cmd.Flags().GetString("plugin-config")
+		onlyEnabled, _ := cmd.Flags().GetBool("only-enabled")
 		enableSentry, _ := cmd.Flags().GetBool("sentry")
 
 		// Enable Sentry.

--- a/cmd/plugin_list.go
+++ b/cmd/plugin_list.go
@@ -16,8 +16,11 @@ var pluginListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the GatewayD plugins",
 	Run: func(cmd *cobra.Command, _ []string) {
+		pluginConfigFile, _ := cmd.Flags().GetString("plugin-config")
+		enableSentry, _ := cmd.Flags().GetBool("sentry")
+
 		// Enable Sentry.
-		if App.EnableSentry {
+		if enableSentry {
 			// Initialize Sentry.
 			err := sentry.Init(sentry.ClientOptions{
 				Dsn:              DSN,
@@ -35,25 +38,20 @@ var pluginListCmd = &cobra.Command{
 			defer sentry.Recover()
 		}
 
-		listPlugins(cmd, App.PluginConfigFile, onlyEnabled)
+		listPlugins(cmd, pluginConfigFile, onlyEnabled)
 	},
 }
 
 func init() {
 	pluginCmd.AddCommand(pluginListCmd)
 
-	App = &GatewayDInstance{}
-
-	pluginListCmd.Flags().StringVarP(
-		&App.PluginConfigFile, // Already exists in run.go
+	pluginListCmd.Flags().StringP(
 		"plugin-config", "p", config.GetDefaultConfigFilePath(config.PluginsConfigFilename),
 		"Plugin config file")
-	pluginListCmd.Flags().BoolVarP(
-		&onlyEnabled,
+	pluginListCmd.Flags().BoolP(
 		"only-enabled", "e",
 		false, "Only list enabled plugins")
-	pluginListCmd.Flags().BoolVar(
-		&App.EnableSentry, "sentry", true, "Enable Sentry") // Already exists in run.go
+	pluginListCmd.Flags().BoolP("sentry", "s", true, "Enable Sentry")
 }
 
 func listPlugins(cmd *cobra.Command, pluginConfigFile string, onlyEnabled bool) {

--- a/cmd/plugin_list.go
+++ b/cmd/plugin_list.go
@@ -55,16 +55,16 @@ func init() {
 
 func listPlugins(cmd *cobra.Command, pluginConfigFile string, onlyEnabled bool) {
 	// Load the plugin config file.
-	conf := config.NewConfig(context.TODO(), config.Config{PluginConfigFile: pluginConfigFile})
-	if err := conf.LoadDefaults(context.TODO()); err != nil {
+	conf := config.NewConfig(context.Background(), config.Config{PluginConfigFile: pluginConfigFile})
+	if err := conf.LoadDefaults(context.Background()); err != nil {
 		cmd.PrintErr(err)
 		return
 	}
-	if err := conf.LoadPluginConfigFile(context.TODO()); err != nil {
+	if err := conf.LoadPluginConfigFile(context.Background()); err != nil {
 		cmd.PrintErr(err)
 		return
 	}
-	if err := conf.UnmarshalPluginConfig(context.TODO()); err != nil {
+	if err := conf.UnmarshalPluginConfig(context.Background()); err != nil {
 		cmd.PrintErr(err)
 		return
 	}

--- a/cmd/plugin_list_test.go
+++ b/cmd/plugin_list_test.go
@@ -11,17 +11,15 @@ import (
 
 func Test_pluginListCmd(t *testing.T) {
 	pluginTestConfigFile := "./test_plugins_pluginListCmd.yaml"
-	// TODO: Hack to ensure the plugin config file is created before running the plugin list command. REMOVE THIS HACK.
-	App.PluginConfigFile = pluginTestConfigFile
 
 	// Test plugin list command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", App.PluginConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
 		output,
 		"plugin init command should have returned the correct output")
-	assert.FileExists(t, App.PluginConfigFile, "plugin init command should have created a config file")
+	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list command should not have returned an error")
@@ -31,7 +29,7 @@ func Test_pluginListCmd(t *testing.T) {
 		"plugin list command should have returned empty output")
 
 	// Clean up.
-	err = os.Remove(App.PluginConfigFile)
+	err = os.Remove(pluginTestConfigFile)
 	assert.Nil(t, err)
 }
 
@@ -39,8 +37,6 @@ func Test_pluginListCmdWithPlugins(t *testing.T) {
 	// Test plugin list command.
 	// Read the plugin config file from the root directory.
 	pluginTestConfigFile := "../gatewayd_plugins.yaml"
-	// TODO: Hack to ensure the plugin config file is created before running the plugin list command. REMOVE THIS HACK.
-	App.PluginConfigFile = pluginTestConfigFile
 
 	output, err := executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list command should not have returned an error")

--- a/cmd/plugin_list_test.go
+++ b/cmd/plugin_list_test.go
@@ -15,10 +15,10 @@ func Test_pluginListCmd(t *testing.T) {
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.Equal(t,
-		fmt.Sprintf("Config file '%s' was created successfully.", pluginTestConfigFile),
+		fmt.Sprintf("Config file '%s' was created successfully.", App.PluginConfigFile),
 		output,
 		"plugin init command should have returned the correct output")
-	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
+	assert.FileExists(t, App.PluginConfigFile, "plugin init command should have created a config file")
 
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list command should not have returned an error")
@@ -28,7 +28,7 @@ func Test_pluginListCmd(t *testing.T) {
 		"plugin list command should have returned empty output")
 
 	// Clean up.
-	err = os.Remove(pluginTestConfigFile)
+	err = os.Remove(App.PluginConfigFile)
 	assert.Nil(t, err)
 }
 

--- a/cmd/plugin_list_test.go
+++ b/cmd/plugin_list_test.go
@@ -11,6 +11,9 @@ import (
 
 func Test_pluginListCmd(t *testing.T) {
 	pluginTestConfigFile := "./test_plugins_pluginListCmd.yaml"
+	// TODO: Hack to ensure the plugin config file is created before running the plugin list command. REMOVE THIS HACK.
+	App.PluginConfigFile = pluginTestConfigFile
+
 	// Test plugin list command.
 	output, err := executeCommandC(rootCmd, "plugin", "init", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
@@ -36,6 +39,9 @@ func Test_pluginListCmdWithPlugins(t *testing.T) {
 	// Test plugin list command.
 	// Read the plugin config file from the root directory.
 	pluginTestConfigFile := "../gatewayd_plugins.yaml"
+	// TODO: Hack to ensure the plugin config file is created before running the plugin list command. REMOVE THIS HACK.
+	App.PluginConfigFile = pluginTestConfigFile
+
 	output, err := executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list command should not have returned an error")
 	assert.Contains(t,

--- a/cmd/plugin_scaffold.go
+++ b/cmd/plugin_scaffold.go
@@ -5,16 +5,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	pluginScaffoldInputFile string
-	pluginScaffoldOutputDir string
-)
-
 // pluginScaffoldCmd represents the scaffold command.
 var pluginScaffoldCmd = &cobra.Command{
 	Use:   "scaffold",
 	Short: "Scaffold a plugin and store the files into a directory",
 	Run: func(cmd *cobra.Command, _ []string) {
+		pluginScaffoldInputFile := cmd.Flag("input-file").Value.String()
+		pluginScaffoldOutputDir := cmd.Flag("output-dir").Value.String()
+
 		createdFiles, err := plugin.Scaffold(pluginScaffoldInputFile, pluginScaffoldOutputDir)
 		if err != nil {
 			cmd.Println("Scaffold failed: ", err)
@@ -31,12 +29,10 @@ var pluginScaffoldCmd = &cobra.Command{
 
 func init() {
 	pluginCmd.AddCommand(pluginScaffoldCmd)
-	pluginScaffoldCmd.Flags().StringVarP(
-		&pluginScaffoldInputFile,
+	pluginScaffoldCmd.Flags().StringP(
 		"input-file", "i", "input.yaml",
 		"Plugin scaffold input file")
-	pluginScaffoldCmd.Flags().StringVarP(
-		&pluginScaffoldOutputDir,
+	pluginScaffoldCmd.Flags().StringP(
 		"output-dir", "o", "./plugins",
 		"Output directory for the scaffold")
 }

--- a/cmd/plugin_scaffold_test.go
+++ b/cmd/plugin_scaffold_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/codingsince1985/checksum"
-	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/testhelpers"
 	"github.com/spf13/cast"
@@ -87,7 +86,7 @@ func Test_pluginScaffoldCmd(t *testing.T) {
 
 	pluginTestConfigFile := filepath.Join(pluginDir, "gatewayd_plugins.yaml")
 
-	stopChan = make(chan struct{})
+	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -114,14 +113,7 @@ func Test_pluginScaffoldCmd(t *testing.T) {
 		StopGracefully(
 			context.Background(),
 			nil,
-			nil,
-			metricsServer,
-			nil,
-			loggers[config.Default],
-			servers,
-			stopChan,
-			nil,
-			nil,
+			App,
 		)
 
 		waitGroup.Done()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,49 +2,24 @@ package cmd
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
-	"fmt"
 	"io"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
-	"os/signal"
-	"runtime"
-	"strconv"
 	"syscall"
 	"time"
 
-	"github.com/NYTimes/gziphandler"
-	sdkAct "github.com/gatewayd-io/gatewayd-plugin-sdk/act"
-	sdkPlugin "github.com/gatewayd-io/gatewayd-plugin-sdk/plugin"
-	v1 "github.com/gatewayd-io/gatewayd-plugin-sdk/plugin/v1"
-	"github.com/gatewayd-io/gatewayd/act"
-	"github.com/gatewayd-io/gatewayd/api"
 	"github.com/gatewayd-io/gatewayd/config"
 	gerr "github.com/gatewayd-io/gatewayd/errors"
-	"github.com/gatewayd-io/gatewayd/logging"
-	"github.com/gatewayd-io/gatewayd/metrics"
 	"github.com/gatewayd-io/gatewayd/network"
-	"github.com/gatewayd-io/gatewayd/plugin"
 	"github.com/gatewayd-io/gatewayd/pool"
 	"github.com/gatewayd-io/gatewayd/raft"
 	"github.com/gatewayd-io/gatewayd/tracing"
-	usage "github.com/gatewayd-io/gatewayd/usagereport/v1"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-co-op/gocron"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var _ io.Writer = &cobraCmdWriter{}
@@ -58,37 +33,10 @@ func (c *cobraCmdWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-type GatewayDInstance struct {
-	EnableTracing     bool
-	EnableSentry      bool
-	EnableLinting     bool
-	EnableUsageReport bool
-	DevMode           bool
-	CollectorURL      string
-	PluginConfigFile  string
-	GlobalConfigFile  string
-
-	conf           *config.Config
-	pluginRegistry *plugin.Registry
-	actRegistry    *act.Registry
-	metricsServer  *http.Server
-	metricsMerger  *metrics.Merger
-	httpServer     *api.HTTPServer
-	grpcServer     *api.GRPCServer
-
-	loggers              map[string]zerolog.Logger
-	pools                map[string]map[string]*pool.Pool
-	clients              map[string]map[string]*config.Client
-	proxies              map[string]map[string]*network.Proxy
-	servers              map[string]*network.Server
-	healthCheckScheduler *gocron.Scheduler
-	stopChan             chan struct{}
-}
-
 var (
 	UsageReportURL = "localhost:59091"
 	testMode       bool
-	testApp        *GatewayDInstance
+	testApp        *GatewayDApp
 )
 
 // EnableTestMode enables test mode and returns the previous value.
@@ -97,105 +45,6 @@ func EnableTestMode() bool {
 	previous := testMode
 	testMode = true
 	return previous
-}
-
-// stopGracefully stops the server gracefully.
-func (app *GatewayDInstance) stopGracefully(runCtx context.Context, sig os.Signal) {
-	_, span := otel.Tracer(config.TracerName).Start(runCtx, "Shutdown server")
-	currentSignal := "unknown"
-	if sig != nil {
-		currentSignal = sig.String()
-	}
-
-	logger := app.loggers[config.Default]
-
-	logger.Info().Msg("Notifying the plugins that the server is shutting down")
-	if app.pluginRegistry != nil {
-		pluginTimeoutCtx, cancel := context.WithTimeout(
-			context.Background(), app.conf.Plugin.Timeout)
-		defer cancel()
-
-		//nolint:contextcheck
-		result, err := app.pluginRegistry.Run(
-			pluginTimeoutCtx,
-			map[string]any{"signal": currentSignal},
-			v1.HookName_HOOK_NAME_ON_SIGNAL,
-		)
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to run OnSignal hooks")
-			span.RecordError(err)
-		}
-		if result != nil {
-			_ = app.pluginRegistry.ActRegistry.RunAll(result) //nolint:contextcheck
-		}
-	}
-
-	logger.Info().Msg("GatewayD is shutting down")
-	span.AddEvent("GatewayD is shutting down", trace.WithAttributes(
-		attribute.String("signal", currentSignal),
-	))
-	if app.healthCheckScheduler != nil {
-		app.healthCheckScheduler.Stop()
-		app.healthCheckScheduler.Clear()
-		logger.Info().Msg("Stopped health check scheduler")
-		span.AddEvent("Stopped health check scheduler")
-	}
-	if app.metricsMerger != nil {
-		app.metricsMerger.Stop()
-		logger.Info().Msg("Stopped metrics merger")
-		span.AddEvent("Stopped metrics merger")
-	}
-	if app.metricsServer != nil {
-		//nolint:contextcheck
-		if err := app.metricsServer.Shutdown(context.Background()); err != nil {
-			logger.Error().Err(err).Msg("Failed to stop metrics server")
-			span.RecordError(err)
-		} else {
-			logger.Info().Msg("Stopped metrics server")
-			span.AddEvent("Stopped metrics server")
-		}
-	}
-	for name, server := range app.servers {
-		logger.Info().Str("name", name).Msg("Stopping server")
-		server.Shutdown()
-		span.AddEvent("Stopped server")
-	}
-	logger.Info().Msg("Stopped all servers")
-	if app.pluginRegistry != nil {
-		app.pluginRegistry.Shutdown()
-		logger.Info().Msg("Stopped plugin registry")
-		span.AddEvent("Stopped plugin registry")
-	}
-	span.End()
-
-	if app.httpServer != nil {
-		app.httpServer.Shutdown(runCtx)
-		logger.Info().Msg("Stopped HTTP Server")
-		span.AddEvent("Stopped HTTP Server")
-	}
-
-	if app.grpcServer != nil {
-		app.grpcServer.Shutdown(runCtx)
-		logger.Info().Msg("Stopped gRPC Server")
-		span.AddEvent("Stopped gRPC Server")
-	}
-
-	// Close the stop channel to notify the other goroutines to stop.
-	app.stopChan <- struct{}{}
-	close(app.stopChan)
-}
-
-// handleSignals handles the signals and stops the server gracefully.
-func (app *GatewayDInstance) handleSignals(runCtx context.Context, signals []os.Signal) {
-	signalsCh := make(chan os.Signal, 1)
-	signal.Notify(signalsCh, signals...)
-
-	go func() {
-		for sig := range signalsCh {
-			app.stopGracefully(runCtx, sig)
-			os.Exit(0)
-		}
-	}()
 }
 
 // runCmd represents the run command.
@@ -214,18 +63,22 @@ var runCmd = &cobra.Command{
 		runCtx, span := otel.Tracer(config.TracerName).Start(context.Background(), "GatewayD")
 		span.End()
 
-		// Setup signal handling after context is created
-		signals := []os.Signal{
-			os.Interrupt,
-			os.Kill,
-			syscall.SIGTERM,
-			syscall.SIGABRT,
-			syscall.SIGQUIT,
-			syscall.SIGHUP,
-			syscall.SIGINT,
-		}
+		// Handle signals from the user.
+		app.handleSignals(
+			runCtx,
+			[]os.Signal{
+				os.Interrupt,
+				os.Kill,
+				syscall.SIGTERM,
+				syscall.SIGABRT,
+				syscall.SIGQUIT,
+				syscall.SIGHUP,
+				syscall.SIGINT,
+			},
+		)
 
-		app.handleSignals(runCtx, signals)
+		// Stop the server gracefully when the program terminates cleanly.
+		defer app.stopGracefully(runCtx, nil)
 
 		// Enable tracing with OpenTelemetry.
 		if app.EnableTracing {
@@ -234,6 +87,7 @@ var runCmd = &cobra.Command{
 			defer func() {
 				if err := shutdown(context.Background()); err != nil {
 					cmd.Println(err)
+					app.stopGracefully(runCtx, nil)
 					os.Exit(gerr.FailedToStartTracer)
 				}
 			}()
@@ -280,670 +134,91 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		// Load global and plugin configuration.
-		app.conf = config.NewConfig(runCtx,
-			config.Config{
-				GlobalConfigFile: app.GlobalConfigFile,
-				PluginConfigFile: app.PluginConfigFile,
-			},
-		)
-		if err := app.conf.InitConfig(runCtx); err != nil {
+		// Load the configuration files.
+		if err := app.loadConfig(runCtx); err != nil {
 			log.Fatal(err)
 		}
 
-		// Create and initialize App.loggers from the config.
-		// Use cobra command cmd instead of os.Stdout for the console output.
-		cmdLogger := &cobraCmdWriter{cmd}
-		for name, cfg := range app.conf.Global.Loggers {
-			app.loggers[name] = logging.NewLogger(runCtx, logging.LoggerConfig{
-				Output:     cfg.GetOutput(),
-				ConsoleOut: cmdLogger,
-				Level: config.If(
-					config.Exists(config.LogLevels, cfg.Level),
-					config.LogLevels[cfg.Level],
-					config.LogLevels[config.DefaultLogLevel],
-				),
-				TimeFormat: config.If(
-					config.Exists(config.TimeFormats, cfg.TimeFormat),
-					config.TimeFormats[cfg.TimeFormat],
-					config.TimeFormats[config.DefaultTimeFormat],
-				),
-				ConsoleTimeFormat: config.If(
-					config.Exists(
-						config.ConsoleTimeFormats, cfg.ConsoleTimeFormat),
-					config.ConsoleTimeFormats[cfg.ConsoleTimeFormat],
-					config.ConsoleTimeFormats[config.DefaultConsoleTimeFormat],
-				),
-				NoColor:        cfg.NoColor,
-				FileName:       cfg.FileName,
-				MaxSize:        cfg.MaxSize,
-				MaxBackups:     cfg.MaxBackups,
-				MaxAge:         cfg.MaxAge,
-				Compress:       cfg.Compress,
-				LocalTime:      cfg.LocalTime,
-				SyslogPriority: cfg.GetSyslogPriority(),
-				RSyslogNetwork: cfg.RSyslogNetwork,
-				RSyslogAddress: cfg.RSyslogAddress,
-				Name:           name,
-			})
-		}
-
-		// Set the default logger.
-		logger := app.loggers[config.Default]
+		// Create and initialize loggers from the config.
+		// And then set the default logger.
+		logger := app.createLoggers(runCtx, cmd)
 
 		if app.DevMode {
 			logger.Warn().Msg(
 				"Running GatewayD in development mode (not recommended for production)")
 		}
 
-		// Create a new act registry given the built-in signals, policies, and actions.
-		var publisher *act.Publisher
-		if app.conf.Plugin.ActionRedis.Enabled {
-			rdb := redis.NewClient(&redis.Options{
-				Addr: app.conf.Plugin.ActionRedis.Address,
-			})
-			var err error
-			publisher, err = act.NewPublisher(act.Publisher{
-				Logger:      logger,
-				RedisDB:     rdb,
-				ChannelName: app.conf.Plugin.ActionRedis.Channel,
-			})
-			if err != nil {
-				logger.Error().Err(err).Msg("Failed to create publisher for act registry")
-				os.Exit(gerr.FailedToCreateActRegistry)
-			}
-			logger.Info().Msg("Created Redis publisher for Act registry")
-		}
-
-		app.actRegistry = act.NewActRegistry(
-			act.Registry{
-				Signals:              act.BuiltinSignals(),
-				Policies:             act.BuiltinPolicies(),
-				Actions:              act.BuiltinActions(),
-				DefaultPolicyName:    app.conf.Plugin.DefaultPolicy,
-				PolicyTimeout:        app.conf.Plugin.PolicyTimeout,
-				DefaultActionTimeout: app.conf.Plugin.ActionTimeout,
-				TaskPublisher:        publisher,
-				Logger:               logger,
-			})
-
-		if app.actRegistry == nil {
-			logger.Error().Msg("Failed to create act registry")
+		// Create the Act registry.
+		if err := app.createActRegistry(logger); err != nil {
+			logger.Error().Err(err).Msg("Failed to create act registry")
+			app.stopGracefully(runCtx, nil)
 			os.Exit(gerr.FailedToCreateActRegistry)
 		}
 
 		// Load policies from the configuration file and add them to the registry.
-		for _, plc := range app.conf.Plugin.Policies {
-			if policy, err := sdkAct.NewPolicy(
-				plc.Name, plc.Policy, plc.Metadata,
-			); err != nil || policy == nil {
-				logger.Error().Err(err).Str("name", plc.Name).Msg("Failed to create policy")
-			} else {
-				app.actRegistry.Add(policy)
-			}
+		if err := app.loadPolicies(logger); err != nil {
+			logger.Error().Err(err).Msg("Failed to load policies")
+			app.stopGracefully(runCtx, nil)
+			os.Exit(gerr.FailedToLoadPolicies)
 		}
 
 		logger.Info().Fields(map[string]any{
 			"policies": maps.Keys(app.actRegistry.Policies),
 		}).Msg("Policies are loaded")
 
-		// Create a new plugin registry.
-		// The plugins are loaded and hooks registered before the configuration is loaded.
-		app.pluginRegistry = plugin.NewRegistry(
-			runCtx,
-			plugin.Registry{
-				ActRegistry: app.actRegistry,
-				Compatibility: config.If(
-					config.Exists(
-						config.CompatibilityPolicies, app.conf.Plugin.CompatibilityPolicy,
-					),
-					config.CompatibilityPolicies[app.conf.Plugin.CompatibilityPolicy],
-					config.DefaultCompatibilityPolicy),
-				Logger:  logger,
-				DevMode: app.DevMode,
-			},
-		)
+		// Create the plugin registry.
+		app.createPluginRegistry(runCtx, logger)
 
 		// Load plugins and register their hooks.
-		app.pluginRegistry.LoadPlugins(runCtx, app.conf.Plugin.Plugins, app.conf.Plugin.StartTimeout)
+		app.pluginRegistry.LoadPlugins(
+			runCtx,
+			app.conf.Plugin.Plugins,
+			app.conf.Plugin.StartTimeout,
+		)
 
 		// Start the metrics merger if enabled.
-		if app.conf.Plugin.EnableMetricsMerger {
-			app.metricsMerger = metrics.NewMerger(runCtx, metrics.Merger{
-				MetricsMergerPeriod: app.conf.Plugin.MetricsMergerPeriod,
-				Logger:              logger,
-			})
-			app.pluginRegistry.ForEach(func(_ sdkPlugin.Identifier, plugin *plugin.Plugin) {
-				if metricsEnabled, err := strconv.ParseBool(plugin.Config["metricsEnabled"]); err == nil && metricsEnabled {
-					app.metricsMerger.Add(plugin.ID.Name, plugin.Config["metricsUnixDomainSocket"])
-					logger.Debug().Str("plugin", plugin.ID.Name).Msg(
-						"Added plugin to metrics merger")
-				}
-			})
-			app.metricsMerger.Start()
-		}
+		app.startMetricsMerger(runCtx, logger)
 
 		// TODO: Move this to the plugin registry.
 		ctx, span := otel.Tracer(config.TracerName).Start(runCtx, "Plugin health check")
 
-		// Ping the plugins to check if they are alive, and remove them if they are not.
-		startDelay := time.Now().Add(app.conf.Plugin.HealthCheckPeriod)
-		if _, err := app.healthCheckScheduler.Every(
-			app.conf.Plugin.HealthCheckPeriod).SingletonMode().StartAt(startDelay).Do(func() {
-			_, span := otel.Tracer(config.TracerName).Start(ctx, "Run plugin health check")
-			defer span.End()
-
-			var plugins []string
-			app.pluginRegistry.ForEach(func(pluginId sdkPlugin.Identifier, plugin *plugin.Plugin) {
-				if err := plugin.Ping(); err != nil {
-					span.RecordError(err)
-					logger.Error().Err(err).Msg("Failed to ping plugin")
-					if app.conf.Plugin.EnableMetricsMerger && app.metricsMerger != nil {
-						app.metricsMerger.Remove(pluginId.Name)
-					}
-					app.pluginRegistry.Remove(pluginId)
-
-					if !app.conf.Plugin.ReloadOnCrash {
-						return // Do not reload the plugins.
-					}
-
-					// Reload the plugins and register their hooks upon crash.
-					logger.Info().Str("name", pluginId.Name).Msg("Reloading crashed plugin")
-					pluginConfig := app.conf.Plugin.GetPlugins(pluginId.Name)
-					if pluginConfig != nil {
-						app.pluginRegistry.LoadPlugins(runCtx, pluginConfig, app.conf.Plugin.StartTimeout)
-					}
-				} else {
-					logger.Trace().Str("name", pluginId.Name).Msg("Successfully pinged plugin")
-					plugins = append(plugins, pluginId.Name)
-				}
-			})
-			span.SetAttributes(attribute.StringSlice("plugins", plugins))
-		}); err != nil {
-			logger.Error().Err(err).Msg("Failed to start plugin health check scheduler")
-			span.RecordError(err)
-		}
-		if app.pluginRegistry.Size() > 0 {
-			logger.Info().Str(
-				"healthCheckPeriod", app.conf.Plugin.HealthCheckPeriod.String(),
-			).Msg("Starting plugin health check scheduler")
-			app.healthCheckScheduler.StartAsync()
-		}
+		// Start the health check scheduler only if there are plugins.
+		app.startHealthCheckScheduler(runCtx, ctx, span, logger)
 
 		span.End()
 
-		// Set the plugin timeout context.
-		pluginTimeoutCtx, cancel := context.WithTimeout(context.Background(), app.conf.Plugin.Timeout)
-		defer cancel()
-
-		// The config will be passed to the plugins that register to the "OnConfigLoaded" plugin.
-		// The plugins can modify the config and return it.
-		updatedGlobalConfig, err := app.pluginRegistry.Run(
-			pluginTimeoutCtx, app.conf.GlobalKoanf.All(), v1.HookName_HOOK_NAME_ON_CONFIG_LOADED)
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to run OnConfigLoaded hooks")
-			span.RecordError(err)
-		}
-		if updatedGlobalConfig != nil {
-			updatedGlobalConfig = app.pluginRegistry.ActRegistry.RunAll(updatedGlobalConfig)
-		}
-
-		// If the config was modified by the plugins, merge it with the one loaded from the file.
-		// Only global configuration is merged, which means that plugins cannot modify the plugin
-		// configurations.
-		if updatedGlobalConfig != nil {
-			// Merge the config with the one loaded from the file (in memory).
-			// The changes won't be persisted to disk.
-			if err := app.conf.MergeGlobalConfig(runCtx, updatedGlobalConfig); err != nil {
-				log.Fatal(err)
-			}
+		// Merge the global config with the one from the plugins.
+		if err := app.onConfigLoaded(runCtx, span, logger); err != nil {
+			app.stopGracefully(runCtx, nil)
+			os.Exit(gerr.FailedToMergeGlobalConfig)
 		}
 
 		// Start the metrics server if enabled.
-		// TODO: Start multiple metrics servers. For now, only one default is supported.
-		// I should first find a use case for those multiple metrics servers.
-		go func(metricsConfig *config.Metrics, logger zerolog.Logger) {
-			_, span := otel.Tracer(config.TracerName).Start(runCtx, "Start metrics server")
-			defer span.End()
-
-			// TODO: refactor this to a separate function.
-			if !metricsConfig.Enabled {
-				logger.Info().Msg("Metrics server is disabled")
-				return
-			}
-
-			scheme := "http://"
-			if metricsConfig.KeyFile != "" && metricsConfig.CertFile != "" {
-				scheme = "https://"
-			}
-
-			fqdn, err := url.Parse(scheme + metricsConfig.Address)
-			if err != nil {
-				logger.Error().Err(err).Msg("Failed to parse metrics address")
-				span.RecordError(err)
-				return
-			}
-
-			address, err := url.JoinPath(fqdn.String(), metricsConfig.Path)
-			if err != nil {
-				logger.Error().Err(err).Msg("Failed to parse metrics path")
-				span.RecordError(err)
-				return
-			}
-
-			// Merge the metrics from the plugins with the ones from GatewayD.
-			mergedMetricsHandler := func(next http.Handler) http.Handler {
-				handler := func(responseWriter http.ResponseWriter, request *http.Request) {
-					if _, err := responseWriter.Write(app.metricsMerger.OutputMetrics); err != nil {
-						logger.Error().Err(err).Msg("Failed to write metrics")
-						span.RecordError(err)
-						sentry.CaptureException(err)
-					}
-					// The WriteHeader method intentionally does nothing, to prevent a bug
-					// in the merging metrics that causes the headers to be written twice,
-					// which results in an error: "http: superfluous response.WriteHeader call".
-					next.ServeHTTP(
-						&metrics.HeaderBypassResponseWriter{
-							ResponseWriter: responseWriter,
-						},
-						request)
-				}
-				return http.HandlerFunc(handler)
-			}
-
-			handler := func() http.Handler {
-				return promhttp.InstrumentMetricHandler(
-					prometheus.DefaultRegisterer,
-					promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
-						DisableCompression: true,
-					}),
-				)
-			}()
-
-			mux := http.NewServeMux()
-			mux.HandleFunc("/", func(responseWriter http.ResponseWriter, _ *http.Request) {
-				// Serve a static page with a link to the metrics endpoint.
-				if _, err := responseWriter.Write([]byte(fmt.Sprintf(
-					`<html><head><title>GatewayD Prometheus Metrics Server</title></head><body><a href="%s">Metrics</a></body></html>`,
-					address,
-				))); err != nil {
-					logger.Error().Err(err).Msg("Failed to write metrics")
-					span.RecordError(err)
-					sentry.CaptureException(err)
-				}
-			})
-
-			if app.conf.Plugin.EnableMetricsMerger && app.metricsMerger != nil {
-				handler = mergedMetricsHandler(handler)
-			}
-
-			readHeaderTimeout := config.If(
-				metricsConfig.ReadHeaderTimeout > 0,
-				metricsConfig.ReadHeaderTimeout,
-				config.DefaultReadHeaderTimeout,
-			)
-
-			// Check if the metrics server is already running before registering the handler.
-			if _, err = http.Get(address); err != nil { //nolint:gosec
-				// The timeout handler limits the nested handlers from running for too long.
-				mux.Handle(
-					metricsConfig.Path,
-					http.TimeoutHandler(
-						gziphandler.GzipHandler(handler),
-						readHeaderTimeout,
-						"The request timed out while fetching the metrics",
-					),
-				)
-			} else {
-				logger.Warn().Msg("Metrics server is already running, consider changing the port")
+		go func(app *GatewayDApp) {
+			if err := app.startMetricsServer(runCtx, logger); err != nil {
+				logger.Error().Err(err).Msg("Failed to start metrics server")
 				span.RecordError(err)
 			}
+		}(app)
 
-			// Create a new metrics server.
-			timeout := config.If(
-				metricsConfig.Timeout > 0,
-				metricsConfig.Timeout,
-				config.DefaultMetricsServerTimeout,
-			)
-			app.metricsServer = &http.Server{
-				Addr:              metricsConfig.Address,
-				Handler:           mux,
-				ReadHeaderTimeout: readHeaderTimeout,
-				ReadTimeout:       timeout,
-				WriteTimeout:      timeout,
-				IdleTimeout:       timeout,
-			}
-
-			logger.Info().Fields(map[string]any{
-				"address":           address,
-				"timeout":           timeout.String(),
-				"readHeaderTimeout": readHeaderTimeout.String(),
-			}).Msg("Metrics are exposed")
-
-			if metricsConfig.CertFile != "" && metricsConfig.KeyFile != "" {
-				// Set up TLS.
-				app.metricsServer.TLSConfig = &tls.Config{
-					MinVersion: tls.VersionTLS13,
-					CurvePreferences: []tls.CurveID{
-						tls.CurveP521,
-						tls.CurveP384,
-						tls.CurveP256,
-					},
-					CipherSuites: []uint16{
-						tls.TLS_AES_128_GCM_SHA256,
-						tls.TLS_AES_256_GCM_SHA384,
-						tls.TLS_CHACHA20_POLY1305_SHA256,
-					},
-				}
-				app.metricsServer.TLSNextProto = make(
-					map[string]func(*http.Server, *tls.Conn, http.Handler))
-				logger.Debug().Msg("Metrics server is running with TLS")
-
-				// Start the metrics server with TLS.
-				if err = app.metricsServer.ListenAndServeTLS(
-					metricsConfig.CertFile, metricsConfig.KeyFile); !errors.Is(err, http.ErrServerClosed) {
-					logger.Error().Err(err).Msg("Failed to start metrics server")
-					span.RecordError(err)
-				}
-			} else {
-				// Start the metrics server without TLS.
-				if err = app.metricsServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-					logger.Error().Err(err).Msg("Failed to start metrics server")
-					span.RecordError(err)
-				}
-			}
-		}(app.conf.Global.Metrics[config.Default], logger)
-
-		// This is a notification hook, so we don't care about the result.
-		pluginTimeoutCtx, cancel = context.WithTimeout(context.Background(), app.conf.Plugin.Timeout)
-		defer cancel()
-
-		if data, ok := app.conf.GlobalKoanf.Get("loggers").(map[string]any); ok {
-			result, err := app.pluginRegistry.Run(
-				pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_LOGGER)
-			if err != nil {
-				logger.Error().Err(err).Msg("Failed to run OnNewLogger hooks")
-				span.RecordError(err)
-			}
-			if result != nil {
-				_ = app.pluginRegistry.ActRegistry.RunAll(result)
-			}
-		} else {
-			logger.Error().Msg("Failed to get loggers from config")
-		}
-
-		// Declare httpServer and grpcServer here as it is used in the StopGracefully function ahead of their definition.
-		var httpServer *api.HTTPServer
-		var grpcServer *api.GRPCServer
+		// Run the OnNewLogger hook.
+		app.onNewLogger(span, logger)
 
 		_, span = otel.Tracer(config.TracerName).Start(runCtx, "Create pools and clients")
-		// Create and initialize pools of connections.
-		for configGroupName, configGroup := range app.conf.Global.Pools {
-			for configBlockName, cfg := range configGroup {
-				logger := app.loggers[configGroupName]
-				// Check if the pool size is greater than zero.
-				currentPoolSize := config.If(
-					cfg.Size > 0,
-					// Check if the pool size is greater than the minimum pool size.
-					config.If(
-						cfg.Size > config.MinimumPoolSize,
-						cfg.Size,
-						config.MinimumPoolSize,
-					),
-					config.DefaultPoolSize,
-				)
 
-				if _, ok := app.pools[configGroupName]; !ok {
-					app.pools[configGroupName] = make(map[string]*pool.Pool)
-				}
-				app.pools[configGroupName][configBlockName] = pool.NewPool(runCtx, currentPoolSize)
-
-				span.AddEvent("Create pool", trace.WithAttributes(
-					attribute.String("name", configBlockName),
-					attribute.Int("size", currentPoolSize),
-				))
-
-				if _, ok := app.clients[configGroupName]; !ok {
-					app.clients[configGroupName] = make(map[string]*config.Client)
-				}
-
-				// Get client config from the config file.
-				if clientConfig, ok := app.conf.Global.Clients[configGroupName][configBlockName]; !ok {
-					// This ensures that the default client config is used if the pool name is not
-					// found in the clients section.
-					app.clients[configGroupName][configBlockName] = app.conf.Global.Clients[config.Default][config.DefaultConfigurationBlock] //nolint:lll
-				} else {
-					// Merge the default client config with the one from the pool.
-					app.clients[configGroupName][configBlockName] = clientConfig
-				}
-
-				// Fill the missing and zero values with the default ones.
-				app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod = config.If(
-					app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod > 0,
-					app.clients[configGroupName][configBlockName].TCPKeepAlivePeriod,
-					config.DefaultTCPKeepAlivePeriod,
-				)
-				app.clients[configGroupName][configBlockName].ReceiveDeadline = config.If(
-					app.clients[configGroupName][configBlockName].ReceiveDeadline > 0,
-					app.clients[configGroupName][configBlockName].ReceiveDeadline,
-					config.DefaultReceiveDeadline,
-				)
-				app.clients[configGroupName][configBlockName].ReceiveTimeout = config.If(
-					app.clients[configGroupName][configBlockName].ReceiveTimeout > 0,
-					app.clients[configGroupName][configBlockName].ReceiveTimeout,
-					config.DefaultReceiveTimeout,
-				)
-				app.clients[configGroupName][configBlockName].SendDeadline = config.If(
-					app.clients[configGroupName][configBlockName].SendDeadline > 0,
-					app.clients[configGroupName][configBlockName].SendDeadline,
-					config.DefaultSendDeadline,
-				)
-				app.clients[configGroupName][configBlockName].ReceiveChunkSize = config.If(
-					app.clients[configGroupName][configBlockName].ReceiveChunkSize > 0,
-					app.clients[configGroupName][configBlockName].ReceiveChunkSize,
-					config.DefaultChunkSize,
-				)
-				app.clients[configGroupName][configBlockName].DialTimeout = config.If(
-					app.clients[configGroupName][configBlockName].DialTimeout > 0,
-					app.clients[configGroupName][configBlockName].DialTimeout,
-					config.DefaultDialTimeout,
-				)
-
-				// Add clients to the pool.
-				for range currentPoolSize {
-					clientConfig := app.clients[configGroupName][configBlockName]
-					clientConfig.GroupName = configGroupName
-					clientConfig.BlockName = configBlockName
-					client := network.NewClient(
-						runCtx, clientConfig, logger,
-						network.NewRetry(
-							network.Retry{
-								Retries: clientConfig.Retries,
-								Backoff: config.If(
-									clientConfig.Backoff > 0,
-									clientConfig.Backoff,
-									config.DefaultBackoff,
-								),
-								BackoffMultiplier:  clientConfig.BackoffMultiplier,
-								DisableBackoffCaps: clientConfig.DisableBackoffCaps,
-								Logger:             app.loggers[configBlockName],
-							},
-						),
-					)
-
-					if client != nil {
-						eventOptions := trace.WithAttributes(
-							attribute.String("name", configBlockName),
-							attribute.String("group", configGroupName),
-							attribute.String("network", client.Network),
-							attribute.String("address", client.Address),
-							attribute.Int("receiveChunkSize", client.ReceiveChunkSize),
-							attribute.String("receiveDeadline", client.ReceiveDeadline.String()),
-							attribute.String("receiveTimeout", client.ReceiveTimeout.String()),
-							attribute.String("sendDeadline", client.SendDeadline.String()),
-							attribute.String("dialTimeout", client.DialTimeout.String()),
-							attribute.Bool("tcpKeepAlive", client.TCPKeepAlive),
-							attribute.String("tcpKeepAlivePeriod", client.TCPKeepAlivePeriod.String()),
-							attribute.String("localAddress", client.LocalAddr()),
-							attribute.String("remoteAddress", client.RemoteAddr()),
-							attribute.Int("retries", clientConfig.Retries),
-							attribute.String("backoff", client.Retry().Backoff.String()),
-							attribute.Float64("backoffMultiplier", clientConfig.BackoffMultiplier),
-							attribute.Bool("disableBackoffCaps", clientConfig.DisableBackoffCaps),
-						)
-						if client.ID != "" {
-							eventOptions = trace.WithAttributes(
-								attribute.String("id", client.ID),
-							)
-						}
-
-						span.AddEvent("Create client", eventOptions)
-
-						pluginTimeoutCtx, cancel = context.WithTimeout(
-							context.Background(), app.conf.Plugin.Timeout)
-						defer cancel()
-
-						clientCfg := map[string]any{
-							"id":                 client.ID,
-							"name":               configBlockName,
-							"group":              configGroupName,
-							"network":            client.Network,
-							"address":            client.Address,
-							"receiveChunkSize":   client.ReceiveChunkSize,
-							"receiveDeadline":    client.ReceiveDeadline.String(),
-							"receiveTimeout":     client.ReceiveTimeout.String(),
-							"sendDeadline":       client.SendDeadline.String(),
-							"dialTimeout":        client.DialTimeout.String(),
-							"tcpKeepAlive":       client.TCPKeepAlive,
-							"tcpKeepAlivePeriod": client.TCPKeepAlivePeriod.String(),
-							"localAddress":       client.LocalAddr(),
-							"remoteAddress":      client.RemoteAddr(),
-							"retries":            clientConfig.Retries,
-							"backoff":            client.Retry().Backoff.String(),
-							"backoffMultiplier":  clientConfig.BackoffMultiplier,
-							"disableBackoffCaps": clientConfig.DisableBackoffCaps,
-						}
-						result, err := app.pluginRegistry.Run(
-							pluginTimeoutCtx, clientCfg, v1.HookName_HOOK_NAME_ON_NEW_CLIENT)
-						if err != nil {
-							logger.Error().Err(err).Msg("Failed to run OnNewClient hooks")
-							span.RecordError(err)
-						}
-						if result != nil {
-							_ = app.pluginRegistry.ActRegistry.RunAll(result)
-						}
-
-						err = app.pools[configGroupName][configBlockName].Put(client.ID, client)
-						if err != nil {
-							logger.Error().Err(err).Msg("Failed to add client to the pool")
-							span.RecordError(err)
-						}
-					} else {
-						logger.Error().Msg("Failed to create client, please check the configuration")
-						go func() {
-							// Wait for the stop signal to exit gracefully.
-							// This prevents the program from waiting indefinitely
-							// after the StopGracefully function is called.
-							<-app.stopChan
-							os.Exit(gerr.FailedToCreateClient)
-						}()
-						app.stopGracefully(runCtx, nil)
-						os.Exit(gerr.FailedToCreateClient)
-					}
-				}
-
-				// Verify that the pool is properly populated.
-				logger.Info().Fields(map[string]any{
-					"name":  configBlockName,
-					"count": strconv.Itoa(app.pools[configGroupName][configBlockName].Size()),
-				}).Msg("There are clients available in the pool")
-
-				if app.pools[configGroupName][configBlockName].Size() != currentPoolSize {
-					logger.Error().Msg(
-						"The pool size is incorrect, either because " +
-							"the clients cannot connect due to no network connectivity " +
-							"or the server is not running. exiting...")
-					app.pluginRegistry.Shutdown()
-					os.Exit(gerr.FailedToInitializePool)
-				}
-
-				pluginTimeoutCtx, cancel = context.WithTimeout(
-					context.Background(), app.conf.Plugin.Timeout)
-				defer cancel()
-
-				result, err := app.pluginRegistry.Run(
-					pluginTimeoutCtx,
-					map[string]any{"name": configBlockName, "size": currentPoolSize},
-					v1.HookName_HOOK_NAME_ON_NEW_POOL)
-				if err != nil {
-					logger.Error().Err(err).Msg("Failed to run OnNewPool hooks")
-					span.RecordError(err)
-				}
-				if result != nil {
-					_ = app.pluginRegistry.ActRegistry.RunAll(result)
-				}
-			}
+		if err := app.createPoolAndClients(runCtx, span); err != nil {
+			logger.Error().Err(err).Msg("Failed to create pools and clients")
+			span.RecordError(err)
+			app.stopGracefully(runCtx, nil)
+			os.Exit(gerr.FailedToCreatePoolAndClients)
 		}
 
 		span.End()
 
 		_, span = otel.Tracer(config.TracerName).Start(runCtx, "Create proxies")
-		// Create and initialize prefork proxies with each pool of clients.
-		for configGroupName, configGroup := range app.conf.Global.Proxies {
-			for configBlockName, cfg := range configGroup {
-				logger := app.loggers[configGroupName]
-				clientConfig := app.clients[configGroupName][configBlockName]
 
-				// Fill the missing and zero value with the default one.
-				cfg.HealthCheckPeriod = config.If(
-					cfg.HealthCheckPeriod > 0,
-					cfg.HealthCheckPeriod,
-					config.DefaultHealthCheckPeriod,
-				)
-
-				if _, ok := app.proxies[configGroupName]; !ok {
-					app.proxies[configGroupName] = make(map[string]*network.Proxy)
-				}
-
-				app.proxies[configGroupName][configBlockName] = network.NewProxy(
-					runCtx,
-					network.Proxy{
-						GroupName:            configGroupName,
-						BlockName:            configBlockName,
-						AvailableConnections: app.pools[configGroupName][configBlockName],
-						PluginRegistry:       app.pluginRegistry,
-						HealthCheckPeriod:    cfg.HealthCheckPeriod,
-						ClientConfig:         clientConfig,
-						Logger:               logger,
-						PluginTimeout:        app.conf.Plugin.Timeout,
-					},
-				)
-
-				span.AddEvent("Create proxy", trace.WithAttributes(
-					attribute.String("name", configBlockName),
-					attribute.String("healthCheckPeriod", cfg.HealthCheckPeriod.String()),
-				))
-
-				pluginTimeoutCtx, cancel = context.WithTimeout(
-					context.Background(), app.conf.Plugin.Timeout)
-				defer cancel()
-
-				if data, ok := app.conf.GlobalKoanf.Get("proxies").(map[string]any); ok {
-					result, err := app.pluginRegistry.Run(
-						pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_PROXY)
-					if err != nil {
-						logger.Error().Err(err).Msg("Failed to run OnNewProxy hooks")
-						span.RecordError(err)
-					}
-					if result != nil {
-						_ = app.pluginRegistry.ActRegistry.RunAll(result)
-					}
-				} else {
-					logger.Error().Msg("Failed to get proxy from config")
-				}
-
-			}
-		}
+		// Create proxies.
+		app.createProxies(runCtx, span)
 
 		span.End()
 
@@ -954,202 +229,28 @@ var runCmd = &cobra.Command{
 		if originalErr != nil {
 			logger.Error().Err(originalErr).Msg("Failed to start raft node")
 			span.RecordError(originalErr)
-			app.pluginRegistry.Shutdown()
+			app.stopGracefully(runCtx, nil)
 			os.Exit(gerr.FailedToStartRaftNode)
 		}
 
 		_, span = otel.Tracer(config.TracerName).Start(runCtx, "Create servers")
-		// Create and initialize servers.
-		for name, cfg := range app.conf.Global.Servers {
-			logger := app.loggers[name]
 
-			var serverProxies []network.IProxy
-			for _, proxy := range app.proxies[name] {
-				serverProxies = append(serverProxies, proxy)
-			}
-
-			app.servers[name] = network.NewServer(
-				runCtx,
-				network.Server{
-					GroupName: name,
-					Network:   cfg.Network,
-					Address:   cfg.Address,
-					TickInterval: config.If(
-						cfg.TickInterval > 0,
-						cfg.TickInterval,
-						config.DefaultTickInterval,
-					),
-					Options: network.Option{
-						// Can be used to send keepalive messages to the client.
-						EnableTicker: cfg.EnableTicker,
-					},
-					Proxies:                    serverProxies,
-					Logger:                     logger,
-					PluginRegistry:             app.pluginRegistry,
-					PluginTimeout:              app.conf.Plugin.Timeout,
-					EnableTLS:                  cfg.EnableTLS,
-					CertFile:                   cfg.CertFile,
-					KeyFile:                    cfg.KeyFile,
-					HandshakeTimeout:           cfg.HandshakeTimeout,
-					LoadbalancerStrategyName:   cfg.LoadBalancer.Strategy,
-					LoadbalancerRules:          cfg.LoadBalancer.LoadBalancingRules,
-					LoadbalancerConsistentHash: cfg.LoadBalancer.ConsistentHash,
-					RaftNode:                   raftNode,
-				},
-			)
-
-			span.AddEvent("Create server", trace.WithAttributes(
-				attribute.String("name", name),
-				attribute.String("network", cfg.Network),
-				attribute.String("address", cfg.Address),
-				attribute.String("tickInterval", cfg.TickInterval.String()),
-				attribute.String("pluginTimeout", app.conf.Plugin.Timeout.String()),
-				attribute.Bool("enableTLS", cfg.EnableTLS),
-				attribute.String("certFile", cfg.CertFile),
-				attribute.String("keyFile", cfg.KeyFile),
-				attribute.String("handshakeTimeout", cfg.HandshakeTimeout.String()),
-			))
-
-			pluginTimeoutCtx, cancel = context.WithTimeout(
-				context.Background(), app.conf.Plugin.Timeout)
-			defer cancel()
-
-			if data, ok := app.conf.GlobalKoanf.Get("servers").(map[string]any); ok {
-				result, err := app.pluginRegistry.Run(
-					pluginTimeoutCtx, data, v1.HookName_HOOK_NAME_ON_NEW_SERVER)
-				if err != nil {
-					logger.Error().Err(err).Msg("Failed to run OnNewServer hooks")
-					span.RecordError(err)
-				}
-				if result != nil {
-					_ = app.pluginRegistry.ActRegistry.RunAll(result)
-				}
-			} else {
-				logger.Error().Msg("Failed to get the servers configuration")
-			}
-		}
+		// Create servers.
+		app.createServers(runCtx, span, raftNode)
 
 		span.End()
 
-		// Start the HTTP and gRPC APIs.
-		if app.conf.Global.API.Enabled {
-			apiOptions := api.Options{
-				Logger:      logger,
-				GRPCNetwork: app.conf.Global.API.GRPCNetwork,
-				GRPCAddress: app.conf.Global.API.GRPCAddress,
-				HTTPAddress: app.conf.Global.API.HTTPAddress,
-				Servers:     app.servers,
-				RaftNode:    raftNode,
-			}
+		// Start the API servers.
+		app.startAPIServers(runCtx, logger, raftNode)
 
-			apiObj := &api.API{
-				Options:        &apiOptions,
-				Config:         app.conf,
-				PluginRegistry: app.pluginRegistry,
-				Pools:          app.pools,
-				Proxies:        app.proxies,
-				Servers:        app.servers,
-			}
-			grpcServer = api.NewGRPCServer(
-				runCtx,
-				api.GRPCServer{
-					API:           apiObj,
-					HealthChecker: &api.HealthChecker{Servers: app.servers},
-				},
-			)
-			if grpcServer != nil {
-				go grpcServer.Start()
-				logger.Info().Str("address", apiOptions.HTTPAddress).Msg("Started the HTTP API")
-
-				httpServer = api.NewHTTPServer(&apiOptions)
-				go httpServer.Start()
-
-				logger.Info().Fields(
-					map[string]any{
-						"network": apiOptions.GRPCNetwork,
-						"address": apiOptions.GRPCAddress,
-					},
-				).Msg("Started the gRPC Server")
-			}
-		}
-
-		// Report usage statistics.
-		if app.EnableUsageReport {
-			go func() {
-				conn, err := grpc.NewClient(
-					UsageReportURL,
-					grpc.WithTransportCredentials(
-						credentials.NewTLS(
-							&tls.Config{
-								MinVersion: tls.VersionTLS12,
-							},
-						),
-					),
-				)
-				if err != nil {
-					logger.Trace().Err(err).Msg(
-						"Failed to dial to the gRPC server for usage reporting")
-				}
-				defer func(conn *grpc.ClientConn) {
-					err := conn.Close()
-					if err != nil {
-						logger.Trace().Err(err).Msg("Failed to close the connection to the usage report service")
-					}
-				}(conn)
-
-				client := usage.NewUsageReportServiceClient(conn)
-				report := usage.UsageReportRequest{
-					Version:        config.Version,
-					RuntimeVersion: runtime.Version(),
-					Goos:           runtime.GOOS,
-					Goarch:         runtime.GOARCH,
-					Service:        "gatewayd",
-					DevMode:        app.DevMode,
-					Plugins:        []*usage.Plugin{},
-				}
-				app.pluginRegistry.ForEach(
-					func(identifier sdkPlugin.Identifier, _ *plugin.Plugin) {
-						report.Plugins = append(report.GetPlugins(), &usage.Plugin{
-							Name:     identifier.Name,
-							Version:  identifier.Version,
-							Checksum: identifier.Checksum,
-						})
-					},
-				)
-				_, err = client.Report(context.Background(), &report)
-				if err != nil {
-					logger.Trace().Err(err).Msg("Failed to report usage statistics")
-				}
-			}()
-		}
+		// Report usage.
+		app.reportUsage(logger)
 
 		_, span = otel.Tracer(config.TracerName).Start(runCtx, "Start servers")
-		// Start the server.
-		for name, server := range app.servers {
-			logger := app.loggers[name]
-			go func(
-				span trace.Span,
-				server *network.Server,
-				logger zerolog.Logger,
-				healthCheckScheduler *gocron.Scheduler,
-				metricsMerger *metrics.Merger,
-				pluginRegistry *plugin.Registry,
-			) {
-				span.AddEvent("Start server")
-				if err := server.Run(); err != nil {
-					logger.Error().Err(err).Msg("Failed to start server")
-					span.RecordError(err)
 
-					healthCheckScheduler.Clear()
-					if metricsMerger != nil {
-						metricsMerger.Stop()
-					}
-					server.Shutdown()
-					pluginRegistry.Shutdown()
-					os.Exit(gerr.FailedToStartServer)
-				}
-			}(span, server, logger, app.healthCheckScheduler, app.metricsMerger, app.pluginRegistry)
-		}
+		// Start the servers.
+		app.startServers(runCtx, span)
+
 		span.End()
 
 		// Wait for the server to shut down.
@@ -1176,8 +277,8 @@ func init() {
 	runCmd.Flags().Bool("metrics-merger", true, "Enable metrics merger")
 }
 
-func NewGatewayDInstance(cmd *cobra.Command) *GatewayDInstance {
-	app := GatewayDInstance{
+func NewGatewayDInstance(cmd *cobra.Command) *GatewayDApp {
+	app := GatewayDApp{
 		loggers:              make(map[string]zerolog.Logger),
 		pools:                make(map[string]map[string]*pool.Pool),
 		clients:              make(map[string]map[string]*config.Client),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1000,7 +1000,7 @@ var runCmd = &cobra.Command{
 				GRPCAddress: App.conf.Global.API.GRPCAddress,
 				HTTPAddress: App.conf.Global.API.HTTPAddress,
 				Servers:     App.servers,
-        RaftNode:    raftNode,
+				RaftNode:    raftNode,
 			}
 
 			apiObj := &api.API{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -155,8 +155,8 @@ func StopGracefully(
 		span.AddEvent("Stopped server")
 	}
 	logger.Info().Msg("Stopped all servers")
-	if App.pluginRegistry != nil {
-		App.pluginRegistry.Shutdown()
+	if app.pluginRegistry != nil {
+		app.pluginRegistry.Shutdown()
 		logger.Info().Msg("Stopped plugin registry")
 		span.AddEvent("Stopped plugin registry")
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -18,6 +18,12 @@ var (
 )
 
 func Test_runCmd(t *testing.T) {
+	previous := EnableTestMode()
+	defer func() {
+		testMode = previous
+		testApp = nil
+	}()
+
 	postgresHostIP, postgresMappedPort := testhelpers.SetupPostgreSQLTestContainer(context.Background(), t)
 	postgresAddress := postgresHostIP + ":" + postgresMappedPort.Port()
 	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS", postgresAddress)
@@ -40,14 +46,13 @@ func Test_runCmd(t *testing.T) {
 	// Check that the config file was created.
 	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
-	App.stopChan = make(chan struct{})
-
 	var waitGroup sync.WaitGroup
 
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		// Test run command.
-		output, err := executeCommandC(rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
+		output, err := executeCommandC(
+			rootCmd, "run", "-c", globalTestConfigFile, "-p", pluginTestConfigFile)
 		require.NoError(t, err, "run command should not have returned an error")
 
 		// Print the output for debugging purposes.
@@ -59,16 +64,11 @@ func Test_runCmd(t *testing.T) {
 		waitGroup.Done()
 	}(&waitGroup)
 
+	// Stop the server after a delay
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		time.Sleep(waitBeforeStop)
-
-		StopGracefully(
-			context.Background(),
-			nil,
-			App,
-		)
-
+		testApp.stopGracefully(context.Background(), os.Interrupt)
 		waitGroup.Done()
 	}(&waitGroup)
 
@@ -80,6 +80,12 @@ func Test_runCmd(t *testing.T) {
 
 // Test_runCmdWithTLS tests the run command with TLS enabled on the server.
 func Test_runCmdWithTLS(t *testing.T) {
+	previous := EnableTestMode()
+	defer func() {
+		testMode = previous
+		testApp = nil
+	}()
+
 	postgresHostIP, postgresMappedPort := testhelpers.SetupPostgreSQLTestContainer(context.Background(), t)
 	postgresAddress := postgresHostIP + ":" + postgresMappedPort.Port()
 	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS", postgresAddress)
@@ -95,8 +101,6 @@ func Test_runCmdWithTLS(t *testing.T) {
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
-
-	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 	// TODO: Test client certificate authentication.
@@ -118,16 +122,11 @@ func Test_runCmdWithTLS(t *testing.T) {
 		waitGroup.Done()
 	}(&waitGroup)
 
+	// Stop the server after a delay
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		time.Sleep(waitBeforeStop)
-
-		StopGracefully(
-			context.Background(),
-			nil,
-			App,
-		)
-
+		testApp.stopGracefully(context.Background(), os.Interrupt)
 		waitGroup.Done()
 	}(&waitGroup)
 
@@ -138,6 +137,12 @@ func Test_runCmdWithTLS(t *testing.T) {
 
 // Test_runCmdWithMultiTenancy tests the run command with multi-tenancy enabled.
 func Test_runCmdWithMultiTenancy(t *testing.T) {
+	previous := EnableTestMode()
+	defer func() {
+		testMode = previous
+		testApp = nil
+	}()
+
 	postgresHostIP, postgresMappedPort := testhelpers.SetupPostgreSQLTestContainer(context.Background(), t)
 	postgresAddress := postgresHostIP + ":" + postgresMappedPort.Port()
 	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS", postgresAddress)
@@ -156,8 +161,6 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
-
-	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -181,16 +184,11 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		waitGroup.Done()
 	}(&waitGroup)
 
+	// Stop the server after a delay
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
 		time.Sleep(waitBeforeStop)
-
-		StopGracefully(
-			context.Background(),
-			nil,
-			App,
-		)
-
+		testApp.stopGracefully(context.Background(), os.Interrupt)
 		waitGroup.Done()
 	}(&waitGroup)
 
@@ -200,6 +198,12 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 }
 
 func Test_runCmdWithCachePlugin(t *testing.T) {
+	previous := EnableTestMode()
+	defer func() {
+		testMode = previous
+		testApp = nil
+	}()
+
 	postgresHostIP, postgresMappedPort := testhelpers.SetupPostgreSQLTestContainer(context.Background(), t)
 	postgresAddress := postgresHostIP + ":" + postgresMappedPort.Port()
 	t.Setenv("GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS", postgresAddress)
@@ -211,8 +215,6 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	globalTestConfigFile := "./test_global_runCmdWithCachePlugin.yaml"
 	pluginTestConfigFile := "./test_plugins_runCmdWithCachePlugin.yaml"
-
-	App.stopChan = make(chan struct{})
 
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
@@ -235,14 +237,15 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		rootCmd, "plugin", "install", "-p", pluginTestConfigFile, "--update", "--backup",
 		"--overwrite-config=true", "--name", "gatewayd-plugin-cache", pluginArchivePath)
 	require.NoError(t, err, "plugin install should not return an error")
-	assert.Equal(t, output, "Installing plugin from CLI argument\nBackup completed successfully\nPlugin binary extracted to plugins/gatewayd-plugin-cache\nPlugin installed successfully\n") //nolint:lll
+	assert.Contains(t, output, "Installing plugin from CLI argument")
+	assert.Contains(t, output, "Backup completed successfully")
+	assert.Contains(t, output, "Plugin binary extracted to plugins/gatewayd-plugin-cache")
+	assert.Contains(t, output, "Plugin installed successfully")
 
 	// See if the plugin was actually installed.
 	output, err = executeCommandC(rootCmd, "plugin", "list", "-p", pluginTestConfigFile)
 	require.NoError(t, err, "plugin list should not return an error")
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
-
-	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -261,16 +264,11 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		waitGroup.Done()
 	}(&waitGroup)
 
+	// Stop the server after a delay
 	waitGroup.Add(1)
 	go func(waitGroup *sync.WaitGroup) {
-		time.Sleep(waitBeforeStop * 2)
-
-		StopGracefully(
-			context.Background(),
-			nil,
-			App,
-		)
-
+		time.Sleep(waitBeforeStop)
+		testApp.stopGracefully(context.Background(), os.Interrupt)
 		waitGroup.Done()
 	}(&waitGroup)
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gatewayd-io/gatewayd/config"
 	"github.com/gatewayd-io/gatewayd/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,7 +40,7 @@ func Test_runCmd(t *testing.T) {
 	// Check that the config file was created.
 	assert.FileExists(t, globalTestConfigFile, "configInitCmd should create a config file")
 
-	stopChan = make(chan struct{})
+	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -67,14 +66,7 @@ func Test_runCmd(t *testing.T) {
 		StopGracefully(
 			context.Background(),
 			nil,
-			nil,
-			metricsServer,
-			nil,
-			loggers[config.Default],
-			servers,
-			stopChan,
-			nil,
-			nil,
+			App,
 		)
 
 		waitGroup.Done()
@@ -104,7 +96,7 @@ func Test_runCmdWithTLS(t *testing.T) {
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
-	stopChan = make(chan struct{})
+	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 	// TODO: Test client certificate authentication.
@@ -133,14 +125,7 @@ func Test_runCmdWithTLS(t *testing.T) {
 		StopGracefully(
 			context.Background(),
 			nil,
-			nil,
-			metricsServer,
-			nil,
-			loggers[config.Default],
-			servers,
-			stopChan,
-			nil,
-			nil,
+			App,
 		)
 
 		waitGroup.Done()
@@ -172,7 +157,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 	require.NoError(t, err, "plugin init command should not have returned an error")
 	assert.FileExists(t, pluginTestConfigFile, "plugin init command should have created a config file")
 
-	stopChan = make(chan struct{})
+	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -203,14 +188,7 @@ func Test_runCmdWithMultiTenancy(t *testing.T) {
 		StopGracefully(
 			context.Background(),
 			nil,
-			nil,
-			metricsServer,
-			nil,
-			loggers[config.Default],
-			servers,
-			stopChan,
-			nil,
-			nil,
+			App,
 		)
 
 		waitGroup.Done()
@@ -233,9 +211,8 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 
 	globalTestConfigFile := "./test_global_runCmdWithCachePlugin.yaml"
 	pluginTestConfigFile := "./test_plugins_runCmdWithCachePlugin.yaml"
-	// TODO: Remove this once these global variables are removed from cmd/run.go.
-	// https://github.com/gatewayd-io/gatewayd/issues/324
-	stopChan = make(chan struct{})
+
+	App.stopChan = make(chan struct{})
 
 	// Create a test plugins config file.
 	_, err := executeCommandC(rootCmd, "plugin", "init", "--force", "-p", pluginTestConfigFile)
@@ -265,7 +242,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 	require.NoError(t, err, "plugin list should not return an error")
 	assert.Contains(t, output, "Name: gatewayd-plugin-cache")
 
-	stopChan = make(chan struct{})
+	App.stopChan = make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
@@ -291,14 +268,7 @@ func Test_runCmdWithCachePlugin(t *testing.T) {
 		StopGracefully(
 			context.Background(),
 			nil,
-			nil,
-			metricsServer,
-			nil,
-			loggers[config.Default],
-			servers,
-			stopChan,
-			nil,
-			nil,
+			App,
 		)
 
 		waitGroup.Done()

--- a/config/getters_test.go
+++ b/config/getters_test.go
@@ -35,9 +35,9 @@ func TestGetDefaultConfigFilePath(t *testing.T) {
 // TestFilter tests the Filter function.
 func TestFilter(t *testing.T) {
 	// Load config from the default config file.
-	conf := NewConfig(context.TODO(),
+	conf := NewConfig(context.Background(),
 		Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	err := conf.InitConfig(context.TODO())
+	err := conf.InitConfig(context.Background())
 	require.Nil(t, err)
 	assert.NotEmpty(t, conf.Global)
 
@@ -55,9 +55,9 @@ func TestFilter(t *testing.T) {
 // TestFilterWithMissingGroupName tests the Filter function with a missing group name.
 func TestFilterWithMissingGroupName(t *testing.T) {
 	// Load config from the default config file.
-	conf := NewConfig(context.TODO(),
+	conf := NewConfig(context.Background(),
 		Config{GlobalConfigFile: "../gatewayd.yaml", PluginConfigFile: "../gatewayd_plugins.yaml"})
-	err := conf.InitConfig(context.TODO())
+	err := conf.InitConfig(context.Background())
 	require.Nil(t, err)
 	assert.NotEmpty(t, conf.Global)
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -214,10 +214,12 @@ var (
 )
 
 const (
-	FailedToCreateClient      = 1
-	FailedToInitializePool    = 2
-	FailedToStartServer       = 3
-	FailedToStartTracer       = 4
-	FailedToCreateActRegistry = 5
-	FailedToStartRaftNode     = 6
+	FailedToCreateClient         = 1
+	FailedToStartServer          = 2
+	FailedToStartTracer          = 3
+	FailedToCreateActRegistry    = 4
+	FailedToLoadPolicies         = 5
+	FailedToStartRaftNode        = 6
+	FailedToMergeGlobalConfig    = 7
+	FailedToCreatePoolAndClients = 8
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -212,14 +212,3 @@ var (
 	// Unwrapped errors.
 	ErrLoggerRequired = errors.New("terminate action requires a logger parameter")
 )
-
-const (
-	FailedToCreateClient         = 1
-	FailedToStartServer          = 2
-	FailedToStartTracer          = 3
-	FailedToCreateActRegistry    = 4
-	FailedToLoadPolicies         = 5
-	FailedToStartRaftNode        = 6
-	FailedToMergeGlobalConfig    = 7
-	FailedToCreatePoolAndClients = 8
-)

--- a/errors/exit_codes.go
+++ b/errors/exit_codes.go
@@ -1,0 +1,12 @@
+package errors
+
+const (
+	FailedToCreateClient         = 1
+	FailedToStartServer          = 2
+	FailedToStartTracer          = 3
+	FailedToCreateActRegistry    = 4
+	FailedToLoadPolicies         = 5
+	FailedToStartRaftNode        = 6
+	FailedToMergeGlobalConfig    = 7
+	FailedToCreatePoolAndClients = 8
+)

--- a/errors/exit_codes.go
+++ b/errors/exit_codes.go
@@ -1,12 +1,11 @@
 package errors
 
 const (
-	FailedToCreateClient         = 1
-	FailedToStartServer          = 2
-	FailedToStartTracer          = 3
-	FailedToCreateActRegistry    = 4
-	FailedToLoadPolicies         = 5
-	FailedToStartRaftNode        = 6
-	FailedToMergeGlobalConfig    = 7
-	FailedToCreatePoolAndClients = 8
+	FailedToStartServer          = 1
+	FailedToStartTracer          = 2
+	FailedToCreateActRegistry    = 3
+	FailedToLoadPolicies         = 4
+	FailedToStartRaftNode        = 5
+	FailedToMergeGlobalConfig    = 6
+	FailedToCreatePoolAndClients = 7
 )

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -215,8 +215,8 @@ func TestRunServer(t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 
 	// check server status and connections
-	assert.False(t, server.running.Load())
-	assert.Zero(t, server.connections)
+	assert.False(t, server.IsRunning())
+	assert.Zero(t, server.CountConnections())
 
 	// Read the log file and check if the log file contains the expected log messages.
 	require.FileExists(t, "server_test.log")

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -109,11 +109,10 @@ func TestRunServer(t *testing.T) {
 		},
 	)
 	assert.NotNil(t, server)
-	assert.Zero(t, server.connections)
 	assert.Zero(t, server.CountConnections())
 	assert.Empty(t, server.host)
 	assert.Empty(t, server.port)
-	assert.False(t, server.running.Load())
+	assert.False(t, server.IsRunning())
 
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(2)


### PR DESCRIPTION
# Ticket(s)

Fixes #324
Fixes #370

## Description

In this PR, I removed global variables in favor of encapsulation within a struct that is initialized locally. Almost all functions now receive parameters instead of relying on those global variables, which improves maintainability. I refactored the `run` command and broken it down into procedural methods within the `GatewayDApp` struct. The functionality remained the same. I added a few tests and improved the existing ones by removing reliance on global variables. I refactored other commands as well. The flags are now processed inside the command's `Run` function, instead of updating global variables, which caused many issues in tests.

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [x] I have ~~added~~updated tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
