### PR TITLE
Log adapter for uniform logging of Raft log messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.2.2+incompatible // indirect
+	github.com/docker/docker v28.3.3+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=
-github.com/docker/docker v28.2.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
+github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/logging/log_adapter.go
+++ b/logging/log_adapter.go
@@ -1,0 +1,67 @@
+package logging
+
+import (
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// StandardLogWriter implements io.Writer to capture standard log output and redirect it to zerolog.
+type StandardLogWriter struct {
+	logger    zerolog.Logger
+	component string
+}
+
+var (
+	// stdlibLogTimestampRegex matches Go stdlib log timestamp format: "2009/01/23 01:23:23 "
+	stdlibLogTimestampRegex = regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}(\.\d{6})?\s`)
+)
+
+// NewStandardLogWriter creates a new StandardLogWriter that redirects standard log output to zerolog.
+func NewStandardLogWriter(logger zerolog.Logger, component string) *StandardLogWriter {
+	return &StandardLogWriter{
+		logger:    logger,
+		component: component,
+	}
+}
+
+// Write implements io.Writer interface and redirects log output to zerolog.
+func (w *StandardLogWriter) Write(p []byte) (n int, err error) {
+	message := string(p)
+
+	// Remove any stdlib log timestamps as defensive measure first
+	message = stdlibLogTimestampRegex.ReplaceAllString(message, "")
+
+	// Then trim whitespace
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return len(p), nil
+	}
+
+	logger := w.logger.With().Str("component", w.component).Logger()
+
+	// For now, we'll log all messages as debug,
+	// until we find a better way to handle log levels.
+	logger.Debug().Msg(message)
+
+	return len(p), nil
+}
+
+// CaptureStandardLogs redirects standard log output to zerolog and returns a restore function.
+func CaptureStandardLogs(logger zerolog.Logger, component string) func() {
+	originalOutput := log.Writer()
+	originalFlags := log.Flags()
+	originalPrefix := log.Prefix()
+
+	logWriter := NewStandardLogWriter(logger, component)
+	log.SetOutput(logWriter)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	return func() {
+		log.SetOutput(originalOutput)
+		log.SetFlags(originalFlags)
+		log.SetPrefix(originalPrefix)
+	}
+}

--- a/logging/log_adapter.go
+++ b/logging/log_adapter.go
@@ -14,12 +14,12 @@ type StandardLogWriter struct {
 	component string
 }
 
-var (
-	// stdlibLogTimestampRegex matches Go stdlib log timestamp format: "2009/01/23 01:23:23 "
-	stdlibLogTimestampRegex = regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}(\.\d{6})?\s`)
-)
+// stdlibLogTimestampRegex matches Go stdlib log timestamp format:
+// "2009/01/23 01:23:23 ".
+var stdlibLogTimestampRegex = regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}(\.\d{6})?\s`)
 
-// NewStandardLogWriter creates a new StandardLogWriter that redirects standard log output to zerolog.
+// NewStandardLogWriter creates a new StandardLogWriter that
+// redirects standard log output to zerolog.
 func NewStandardLogWriter(logger zerolog.Logger, component string) *StandardLogWriter {
 	return &StandardLogWriter{
 		logger:    logger,
@@ -28,13 +28,13 @@ func NewStandardLogWriter(logger zerolog.Logger, component string) *StandardLogW
 }
 
 // Write implements io.Writer interface and redirects log output to zerolog.
-func (w *StandardLogWriter) Write(p []byte) (n int, err error) {
+func (w *StandardLogWriter) Write(p []byte) (int, error) {
 	message := string(p)
 
-	// Remove any stdlib log timestamps as defensive measure first
+	// Remove any stdlib log timestamps as defensive measure first.
 	message = stdlibLogTimestampRegex.ReplaceAllString(message, "")
 
-	// Then trim whitespace
+	// Then trim whitespace.
 	message = strings.TrimSpace(message)
 	if message == "" {
 		return len(p), nil

--- a/logging/log_adapter.go
+++ b/logging/log_adapter.go
@@ -28,8 +28,8 @@ func NewStandardLogWriter(logger zerolog.Logger, component string) *StandardLogW
 }
 
 // Write implements io.Writer interface and redirects log output to zerolog.
-func (w *StandardLogWriter) Write(p []byte) (int, error) {
-	message := string(p)
+func (w *StandardLogWriter) Write(logLine []byte) (int, error) {
+	message := string(logLine)
 
 	// Remove any stdlib log timestamps as defensive measure first.
 	message = stdlibLogTimestampRegex.ReplaceAllString(message, "")
@@ -37,7 +37,7 @@ func (w *StandardLogWriter) Write(p []byte) (int, error) {
 	// Then trim whitespace.
 	message = strings.TrimSpace(message)
 	if message == "" {
-		return len(p), nil
+		return len(logLine), nil
 	}
 
 	logger := w.logger.With().Str("component", w.component).Logger()
@@ -46,7 +46,7 @@ func (w *StandardLogWriter) Write(p []byte) (int, error) {
 	// until we find a better way to handle log levels.
 	logger.Debug().Msg(message)
 
-	return len(p), nil
+	return len(logLine), nil
 }
 
 // CaptureStandardLogs redirects standard log output to zerolog and returns a restore function.

--- a/logging/log_adapter_test.go
+++ b/logging/log_adapter_test.go
@@ -1,0 +1,168 @@
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandardLogWriter_Write(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "message without timestamp",
+			input:    "simple log message",
+			expected: "simple log message",
+		},
+		{
+			name:     "message with Go stdlib LstdFlags format (default)",
+			input:    "2025/01/15 10:17:53 log message here",
+			expected: "log message here",
+		},
+		{
+			name:     "message with Go stdlib Ldate|Ltime|Lmicroseconds format",
+			input:    "2025/01/15 10:17:53.123456 log message here",
+			expected: "log message here",
+		},
+		{
+			name:     "message with exact Go stdlib format (zero-padded)",
+			input:    "2009/01/23 01:23:23 log message here",
+			expected: "log message here",
+		},
+		{
+			name:     "empty message",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only Go stdlib timestamp",
+			input:    "2025/01/15 10:17:53 ",
+			expected: "",
+		},
+		{
+			name:     "message with multiple spaces after Go stdlib timestamp",
+			input:    "2025/01/15 10:17:53   log message with spaces",
+			expected: "log message with spaces",
+		},
+		{
+			name:     "non-Go stdlib timestamp format should not be removed",
+			input:    "2025-01-15 10:17:53 log message",
+			expected: "2025-01-15 10:17:53 log message",
+		},
+		{
+			name:     "time-only format should not be removed",
+			input:    "10:17:53 log message",
+			expected: "10:17:53 log message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a buffer to capture the log output
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+			// Create the writer
+			writer := NewStandardLogWriter(logger, "test-component")
+
+			// Write the test input
+			n, err := writer.Write([]byte(tt.input))
+
+			// Verify no error and correct byte count
+			require.NoError(t, err)
+			assert.Equal(t, len(tt.input), n)
+
+			// Parse the output
+			output := buf.String()
+
+			if tt.expected == "" {
+				// If we expect empty, the logger shouldn't have written anything
+				assert.Empty(t, output)
+			} else {
+				// Verify the message was logged correctly
+				assert.Contains(t, output, tt.expected)
+				assert.Contains(t, output, `"component":"test-component"`)
+				assert.Contains(t, output, `"level":"debug"`)
+			}
+		})
+	}
+}
+
+func TestStdlibLogTimestampRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Go stdlib LstdFlags format (Ldate | Ltime)",
+			input:    "2025/01/15 10:17:53 message",
+			expected: "message",
+		},
+		{
+			name:     "Go stdlib with microseconds",
+			input:    "2025/01/15 10:17:53.123456 message",
+			expected: "message",
+		},
+		{
+			name:     "exact Go reference time format",
+			input:    "2009/01/23 01:23:23 message",
+			expected: "message",
+		},
+		{
+			name:     "non-Go stdlib ISO format should NOT match",
+			input:    "2025-01-15 10:17:53 message",
+			expected: "2025-01-15 10:17:53 message",
+		},
+		{
+			name:     "time only should NOT match",
+			input:    "10:17:53 message",
+			expected: "10:17:53 message",
+		},
+		{
+			name:     "single digit day/month should NOT match (Go uses zero-padding)",
+			input:    "2025/1/5 10:17:53 message",
+			expected: "2025/1/5 10:17:53 message",
+		},
+		{
+			name:     "no timestamp",
+			input:    "just a message",
+			expected: "just a message",
+		},
+		{
+			name:     "timestamp at end (should not match)",
+			input:    "message 2025/01/15 10:17:53",
+			expected: "message 2025/01/15 10:17:53",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stdlibLogTimestampRegex.ReplaceAllString(tt.input, "")
+			result = strings.TrimSpace(result)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCaptureStandardLogs(t *testing.T) {
+	// Create a buffer to capture the log output
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+	// Test that the function returns a restore function
+	restore := CaptureStandardLogs(logger, "test-capture")
+	assert.NotNil(t, restore)
+
+	// Test that we can call the restore function without error
+	assert.NotPanics(t, func() {
+		restore()
+	})
+}

--- a/logging/log_adapter_test.go
+++ b/logging/log_adapter_test.go
@@ -63,8 +63,8 @@ func TestStandardLogWriter_Write(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
 			// Create a buffer to capture the log output
 			var buf bytes.Buffer
 			logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
@@ -73,21 +73,21 @@ func TestStandardLogWriter_Write(t *testing.T) {
 			writer := NewStandardLogWriter(logger, "test-component")
 
 			// Write the test input
-			n, err := writer.Write([]byte(tt.input))
+			n, err := writer.Write([]byte(testCase.input))
 
 			// Verify no error and correct byte count
 			require.NoError(t, err)
-			assert.Equal(t, len(tt.input), n)
+			assert.Equal(t, len(testCase.input), n)
 
 			// Parse the output
 			output := buf.String()
 
-			if tt.expected == "" {
+			if testCase.expected == "" {
 				// If we expect empty, the logger shouldn't have written anything
 				assert.Empty(t, output)
 			} else {
 				// Verify the message was logged correctly
-				assert.Contains(t, output, tt.expected)
+				assert.Contains(t, output, testCase.expected)
 				assert.Contains(t, output, `"component":"test-component"`)
 				assert.Contains(t, output, `"level":"debug"`)
 			}
@@ -143,11 +143,11 @@ func TestStdlibLogTimestampRegex(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := stdlibLogTimestampRegex.ReplaceAllString(tt.input, "")
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := stdlibLogTimestampRegex.ReplaceAllString(testCase.input, "")
 			result = strings.TrimSpace(result)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, testCase.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
# Ticket(s)

Fixes #687 

## Description

This PR creates a log adapter that wraps Go's log package to prevent non-uniform logging.

<img width="1911" height="187" alt="image" src="https://github.com/user-attachments/assets/55f8bb3e-9f02-435e-af5f-5a5be2121ca2" />

## Related PRs

N/A

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
