### PR TITLE
Handle hclog format string properly

### DIFF
--- a/act/act_helpers_test.go
+++ b/act/act_helpers_test.go
@@ -1,6 +1,8 @@
 package act
 
 import (
+	"io"
+	"log"
 	"testing"
 	"time"
 
@@ -72,6 +74,7 @@ func createTestRedis(t *testing.T) string {
 				),
 			},
 			Started: true,
+			Logger:  log.New(io.Discard, "", 0),
 		},
 	)
 	assert.NoError(t, err)

--- a/act/builtins_test.go
+++ b/act/builtins_test.go
@@ -47,7 +47,7 @@ func Test_Terminate_Action(t *testing.T) {
 			params: []sdkAct.Parameter{
 				{
 					Key:   LoggerKey,
-					Value: zerolog.New(nil),
+					Value: zerolog.Nop(),
 				},
 			},
 			result: true,
@@ -56,7 +56,7 @@ func Test_Terminate_Action(t *testing.T) {
 			params: []sdkAct.Parameter{
 				{
 					Key:   LoggerKey,
-					Value: zerolog.New(nil),
+					Value: zerolog.Nop(),
 				},
 				{
 					Key:   ResultKey,
@@ -69,7 +69,7 @@ func Test_Terminate_Action(t *testing.T) {
 			params: []sdkAct.Parameter{
 				{
 					Key:   LoggerKey,
-					Value: zerolog.New(nil),
+					Value: zerolog.Nop(),
 				},
 				{
 					Key:   ResultKey,
@@ -114,7 +114,7 @@ func Test_Log_Action(t *testing.T) {
 			params: []sdkAct.Parameter{
 				{
 					Key:   LoggerKey,
-					Value: zerolog.New(nil),
+					Value: zerolog.Nop(),
 				},
 			},
 			result: true,

--- a/act/registry_test.go
+++ b/act/registry_test.go
@@ -20,7 +20,7 @@ import (
 
 // Test_NewRegistry tests the NewRegistry function.
 func Test_NewRegistry(t *testing.T) {
-	logger := zerolog.Logger{}
+	logger := zerolog.Nop()
 
 	actRegistry := NewActRegistry(
 		Registry{
@@ -129,7 +129,7 @@ func Test_Add(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 	assert.NotNil(t, actRegistry)
 
@@ -196,7 +196,7 @@ func Test_Apply(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 	assert.NotNil(t, actRegistry)
 
@@ -593,7 +593,7 @@ func Test_Apply_Hook(t *testing.T) {
 
 // Test_Run tests the Run function of the act registry with a non-terminal action.
 func Test_Run(t *testing.T) {
-	logger := zerolog.Logger{}
+	logger := zerolog.Nop()
 	actRegistry := NewActRegistry(
 		Registry{
 			Signals:              BuiltinSignals(),
@@ -623,7 +623,7 @@ func Test_Run(t *testing.T) {
 
 // Test_Run_Terminate tests the Run function of the act registry with a terminal action.
 func Test_Run_Terminate(t *testing.T) {
-	logger := zerolog.Logger{}
+	logger := zerolog.Nop()
 	actRegistry := NewActRegistry(
 		Registry{
 			Signals:              BuiltinSignals(),

--- a/api/api_helpers_test.go
+++ b/api/api_helpers_test.go
@@ -13,7 +13,7 @@ import (
 
 // getAPIConfig returns a new API configuration with all the necessary components.
 func getAPIConfig(httpAddr, grpcAddr string) *API {
-	logger := zerolog.New(nil)
+	logger := zerolog.Nop()
 	defaultPool := pool.NewPool(context.Background(), config.DefaultPoolSize)
 	pluginReg := plugin.NewRegistry(
 		context.Background(),

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"io"
 	"regexp"
 	"testing"
 	"time"
@@ -137,13 +136,13 @@ func TestGetPlugins(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 	pluginRegistry := plugin.NewRegistry(
 		t.Context(),
 		plugin.Registry{
 			ActRegistry: actRegistry,
-			Logger:      zerolog.Logger{},
+			Logger:      zerolog.Nop(),
 			DevMode:     true,
 		},
 	)
@@ -191,13 +190,13 @@ func TestGetPluginsWithEmptyPluginRegistry(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 	pluginRegistry := plugin.NewRegistry(
 		t.Context(),
 		plugin.Registry{
 			ActRegistry: actRegistry,
-			Logger:      zerolog.Logger{},
+			Logger:      zerolog.Nop(),
 			DevMode:     true,
 		},
 	)
@@ -250,7 +249,7 @@ func TestGetProxies(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(t.Context(), clientConfig, zerolog.Logger{}, nil)
+	client := network.NewClient(t.Context(), clientConfig, zerolog.Nop(), nil)
 	require.NotNil(t, client)
 	newPool := pool.NewPool(t.Context(), 1)
 	assert.Nil(t, newPool.Put(client.ID, client))
@@ -264,7 +263,7 @@ func TestGetProxies(t *testing.T) {
 				Network: config.DefaultNetwork,
 				Address: postgresAddress,
 			},
-			Logger:        zerolog.Logger{},
+			Logger:        zerolog.Nop(),
 			PluginTimeout: config.DefaultPluginTimeout,
 		},
 	)
@@ -302,7 +301,7 @@ func TestGetServers(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(t.Context(), clientConfig, zerolog.Logger{}, nil)
+	client := network.NewClient(t.Context(), clientConfig, zerolog.Nop(), nil)
 	newPool := pool.NewPool(t.Context(), 1)
 	require.NotNil(t, newPool)
 	assert.Nil(t, newPool.Put(client.ID, client))
@@ -316,7 +315,7 @@ func TestGetServers(t *testing.T) {
 				Network: config.DefaultNetwork,
 				Address: postgresAddress,
 			},
-			Logger:        zerolog.Logger{},
+			Logger:        zerolog.Nop(),
 			PluginTimeout: config.DefaultPluginTimeout,
 		},
 	)
@@ -329,14 +328,14 @@ func TestGetServers(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 
 	pluginRegistry := plugin.NewRegistry(
 		t.Context(),
 		plugin.Registry{
 			ActRegistry: actRegistry,
-			Logger:      zerolog.Logger{},
+			Logger:      zerolog.Nop(),
 			DevMode:     true,
 		},
 	)
@@ -351,7 +350,7 @@ func TestGetServers(t *testing.T) {
 				EnableTicker: false,
 			},
 			Proxies:                  []network.IProxy{proxy},
-			Logger:                   zerolog.Logger{},
+			Logger:                   zerolog.Nop(),
 			PluginRegistry:           pluginRegistry,
 			PluginTimeout:            config.DefaultPluginTimeout,
 			HandshakeTimeout:         config.DefaultHandshakeTimeout,
@@ -445,7 +444,7 @@ func TestRemovePeerAPI(t *testing.T) {
 
 	// Initialize nodes
 	for i, cfg := range nodeConfigs {
-		node, err := raft.NewRaftNode(zerolog.New(io.Discard).With().Timestamp().Logger(), cfg)
+		node, err := raft.NewRaftNode(zerolog.Nop().With().Timestamp().Logger(), cfg)
 		require.NoError(t, err)
 		nodes[i] = node
 	}
@@ -478,7 +477,7 @@ func TestRemovePeerAPI(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: nodes[0],
 				},
 			},
@@ -490,7 +489,7 @@ func TestRemovePeerAPI(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: nil,
 				},
 			},
@@ -503,7 +502,7 @@ func TestRemovePeerAPI(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: nodes[0],
 				},
 			},
@@ -545,7 +544,7 @@ func TestGetPeers(t *testing.T) {
 	}
 
 	// Initialize node
-	node, err := raft.NewRaftNode(zerolog.New(io.Discard).With().Timestamp().Logger(), nodeConfig)
+	node, err := raft.NewRaftNode(zerolog.Nop().With().Timestamp().Logger(), nodeConfig)
 	require.NoError(t, err)
 	defer func() {
 		if node != nil {
@@ -569,7 +568,7 @@ func TestGetPeers(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: node,
 				},
 			},
@@ -580,7 +579,7 @@ func TestGetPeers(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: nil,
 				},
 			},
@@ -634,7 +633,7 @@ func TestAddPeer(t *testing.T) {
 	}
 
 	// Initialize node
-	node, err := raft.NewRaftNode(zerolog.New(io.Discard).With().Timestamp().Logger(), nodeConfig)
+	node, err := raft.NewRaftNode(zerolog.Nop().With().Timestamp().Logger(), nodeConfig)
 	require.NoError(t, err)
 	defer func() {
 		if node != nil {
@@ -659,7 +658,7 @@ func TestAddPeer(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: node,
 				},
 			},
@@ -675,7 +674,7 @@ func TestAddPeer(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: nil,
 				},
 			},
@@ -692,7 +691,7 @@ func TestAddPeer(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: node,
 				},
 			},
@@ -708,7 +707,7 @@ func TestAddPeer(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: node,
 				},
 			},
@@ -724,7 +723,7 @@ func TestAddPeer(t *testing.T) {
 			api: &API{
 				ctx: t.Context(),
 				Options: &Options{
-					Logger:   zerolog.New(io.Discard),
+					Logger:   zerolog.Nop(),
 					RaftNode: node,
 				},
 			},

--- a/api/healthcheck_test.go
+++ b/api/healthcheck_test.go
@@ -23,7 +23,7 @@ func Test_Healthchecker(t *testing.T) {
 		Network: config.DefaultNetwork,
 		Address: postgresAddress,
 	}
-	client := network.NewClient(t.Context(), clientConfig, zerolog.Logger{}, nil)
+	client := network.NewClient(t.Context(), clientConfig, zerolog.Nop(), nil)
 	newPool := pool.NewPool(t.Context(), 1)
 	require.NotNil(t, newPool)
 	assert.Nil(t, newPool.Put(client.ID, client))
@@ -37,7 +37,7 @@ func Test_Healthchecker(t *testing.T) {
 				Network: config.DefaultNetwork,
 				Address: postgresAddress,
 			},
-			Logger:        zerolog.Logger{},
+			Logger:        zerolog.Nop(),
 			PluginTimeout: config.DefaultPluginTimeout,
 		},
 	)
@@ -50,14 +50,14 @@ func Test_Healthchecker(t *testing.T) {
 			DefaultPolicyName:    config.DefaultPolicy,
 			PolicyTimeout:        config.DefaultPolicyTimeout,
 			DefaultActionTimeout: config.DefaultActionTimeout,
-			Logger:               zerolog.Logger{},
+			Logger:               zerolog.Nop(),
 		})
 
 	pluginRegistry := plugin.NewRegistry(
 		t.Context(),
 		plugin.Registry{
 			ActRegistry: actRegistry,
-			Logger:      zerolog.Logger{},
+			Logger:      zerolog.Nop(),
 			DevMode:     true,
 		},
 	)
@@ -82,7 +82,7 @@ func Test_Healthchecker(t *testing.T) {
 				EnableTicker: false,
 			},
 			Proxies:          []network.IProxy{proxy},
-			Logger:           zerolog.Logger{},
+			Logger:           zerolog.Nop(),
 			PluginRegistry:   pluginRegistry,
 			PluginTimeout:    config.DefaultPluginTimeout,
 			HandshakeTimeout: config.DefaultHandshakeTimeout,

--- a/logging/hclog_adapter.go
+++ b/logging/hclog_adapter.go
@@ -190,12 +190,19 @@ func ToMap(keyValues []any) map[string]any {
 		keyValues = append(keyValues, nil)
 	}
 
-	for i := 0; i < len(keyValues); i += 2 {
-		key := keyValues[i]
-		value := keyValues[i+1]
+	for idx := 0; idx < len(keyValues); idx += 2 {
+		key := keyValues[idx]
+		value := keyValues[idx+1]
 
-		if formatString, ok := value.(hclog.Format); ok {
-			value = fmt.Sprintf(formatString[0].(string), formatString[1:]...)
+		if formatted, ok := value.(hclog.Format); ok {
+			formatStr, ok := formatted[0].(string)
+			if !ok {
+				// Default to %+v if the format string is not a string
+				// This should never happen, but we'll handle it just in case.
+				formatStr = "%+v"
+			}
+
+			value = fmt.Sprintf(formatStr, formatted[1:]...)
 		}
 
 		merge(mapped, key, value)

--- a/logging/hclog_adapter.go
+++ b/logging/hclog_adapter.go
@@ -191,12 +191,14 @@ func ToMap(keyValues []any) map[string]any {
 	}
 
 	for i := 0; i < len(keyValues); i += 2 {
-		if formatString, ok := keyValues[i+1].(hclog.Format); ok {
-			merge(mapped, keyValues[i], fmt.Sprintf(formatString[0].(string), formatString[1:]...))
-			continue
+		key := keyValues[i]
+		value := keyValues[i+1]
+
+		if formatString, ok := value.(hclog.Format); ok {
+			value = fmt.Sprintf(formatString[0].(string), formatString[1:]...)
 		}
 
-		merge(mapped, keyValues[i], keyValues[i+1])
+		merge(mapped, key, value)
 	}
 
 	return mapped

--- a/logging/hclog_adapter.go
+++ b/logging/hclog_adapter.go
@@ -179,6 +179,11 @@ func convertLevel(level hclog.Level) zerolog.Level {
 	return zerolog.NoLevel
 }
 
+// isFormatString checks if a string looks like a printf-style format string
+func isFormatString(s string) bool {
+	return len(s) >= 2 && s[0] == '%' && s[1] != '%'
+}
+
 func ToMap(keyValues []any) map[string]any {
 	mapped := map[string]any{}
 
@@ -191,6 +196,11 @@ func ToMap(keyValues []any) map[string]any {
 	}
 
 	for i := 0; i < len(keyValues); i += 2 {
+		if formatString, ok := keyValues[i+1].(hclog.Format); ok {
+			merge(mapped, keyValues[i], fmt.Sprintf(formatString[0].(string), formatString[1:]...))
+			continue
+		}
+
 		merge(mapped, keyValues[i], keyValues[i+1])
 	}
 

--- a/logging/hclog_adapter.go
+++ b/logging/hclog_adapter.go
@@ -179,11 +179,6 @@ func convertLevel(level hclog.Level) zerolog.Level {
 	return zerolog.NoLevel
 }
 
-// isFormatString checks if a string looks like a printf-style format string
-func isFormatString(s string) bool {
-	return len(s) >= 2 && s[0] == '%' && s[1] != '%'
-}
-
 func ToMap(keyValues []any) map[string]any {
 	mapped := map[string]any{}
 

--- a/logging/hclog_adapter_test.go
+++ b/logging/hclog_adapter_test.go
@@ -35,6 +35,10 @@ func TestNewHcLogAdapter(t *testing.T) {
 	hcLogAdapter.Warn("This is a warn message")
 	hcLogAdapter.Error("This is an error message")
 	hcLogAdapter.Log(hclog.Debug, "This is a log message")
+	hcLogAdapter.Log(hclog.Info,
+		"This is an info message with a format string",
+		"test", hclog.Format{"%+v", []struct{ Key string }{{Key: "value"}}},
+	)
 
 	hcLogAdapter.SetLevel(hclog.Warn)
 	hcLogAdapter.Trace("This is a trace message, but it should not be logged")
@@ -47,6 +51,8 @@ func TestNewHcLogAdapter(t *testing.T) {
 	assert.Contains(t, consoleOutput, "WRN This is a warn message")
 	assert.Contains(t, consoleOutput, "ERR This is an error message")
 	assert.Contains(t, consoleOutput, "DBG This is a log message")
+	assert.Contains(t, consoleOutput, "INF This is an info message with a format string")
+	assert.Contains(t, consoleOutput, "[{Key:value}]")
 
 	assert.NotContains(t, consoleOutput, "TRC This is a trace message, but it should not be logged")
 }

--- a/plugin/utils_test.go
+++ b/plugin/utils_test.go
@@ -89,7 +89,7 @@ func Test_getSignals_empty(t *testing.T) {
 // Test_applyPolicies tests the applyPolicies function with a passthrough policy.
 // It also tests the Run function of the registered passthrough (built-in) action.
 func Test_applyPolicies(t *testing.T) {
-	logger := zerolog.Logger{}
+	logger := zerolog.Nop()
 	actRegistry := act.NewActRegistry(
 		act.Registry{
 			Signals:              act.BuiltinSignals(),

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func setupTestLogger() zerolog.Logger {
-	return zerolog.New(io.Discard).With().Timestamp().Logger()
+	return zerolog.Nop().With().Timestamp().Logger()
 }
 
 func TestNewRaftNode(t *testing.T) {


### PR DESCRIPTION
# Ticket(s)

N/A

## Description

The [hclog Format](https://github.com/hashicorp/go-hclog/blob/51a34ed3823a210e2e396aea9e5757d85b3c29d7/logger.go#L50-L54) wasn't being handled properly in logs, as show below:

<img width="1888" height="66" alt="image" src="https://github.com/user-attachments/assets/f4beb948-e2cd-4252-a0e0-1072316d9bdf" />

This PR fixes it:

<img width="1881" height="61" alt="image" src="https://github.com/user-attachments/assets/490fc379-f3b5-4fd5-af8d-79267b67891c" />

Note: while fixing this, I also updated all loggers in tests to use a no-op logger to avoid cluttering the output. Loggers that redirected their output to a buffer were left intact, otherwise their tests would fail.

## Related PRs

## Development Checklist

<!--
Not all of these are mandatory or sometimes relevant.
Please ignore any that don't apply to your PR.
-->

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have updated docs using `make gen-docs` command.
- [x] I have added tests for my changes.
- [x] I have signed all the commits.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
